### PR TITLE
feat: enable app_commands + add /links slash command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ The token-expiry math used `datetime.now()` (naive local) against `Credentials.e
 - `published.txt` is the source of truth for "already announced". It's seeded on first run from the latest 20 uploads if missing — don't delete it on a live deployment or you'll re-announce.
 - The OAuth token must be refreshed periodically; the bot itself only *warns* about expiry, it does not auto-renew the consent flow.
 - The YouTube client and upload-playlist ID are lazy-initialized via `@lru_cache` in `youtube.py` — first call triggers OAuth and the channel lookup.
-- The bot is event-driven, not command-driven; no slash commands are registered, so `bot.tree.sync()` is intentionally not called.
+- Slash commands live in `acelerado/slash.py`. `register_commands(tree, guild=...)` is called from `bot.setup_hook` and pushed via `tree.sync(guild=...)` — guild-scoped so changes propagate instantly. To add a new slash command: define it with `@app_commands.command(...)` in `slash.py`, add `tree.add_command(new_cmd, guild=guild)` inside `register_commands`, add a registration test in `tests/test_slash.py`. The bot is otherwise event-driven (no message-prefixed commands).
 
 ## Fail-proof contract
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,17 @@ uv sync
 
    Na primeira execução que precisar da API do YouTube (por ex. `acelerado run` ou `acelerado refresh-token`), o navegador abrirá para consentimento e o token será salvo em `token.pickle`.
 
+## Slash commands no Discord
+
+| Comando | Descrição |
+|---------|-----------|
+| `/links` | Lista os canais/redes oficiais (resposta ephemeral, só você vê). |
+
+Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
+
 ## Uso — CLI
 
-Toda a funcionalidade é exposta por um único entrypoint `acelerado`, montado com `typer`:
+Toda a funcionalidade administrativa é exposta por um único entrypoint `acelerado`, montado com `typer`:
 
 ```sh
 uv run acelerado --help

--- a/acelerado/bot.py
+++ b/acelerado/bot.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands, tasks
 
 from acelerado.env import get_env
+from acelerado.slash import register_commands
 from acelerado.state import AceleradoState
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,16 @@ class AceleradoBot(commands.Bot):
         # configured value before the first tick.
         self.event_loop_task.change_interval(seconds=get_env().ACELERADO_TICK_SECONDS)
         self.event_loop_task.start()
+
+        # Register slash commands and sync them guild-scoped — propagates
+        # instantly, unlike global sync (~1h). Bot is single-guild today.
+        guild = discord.Object(id=get_env().DISCORD_GUILD_ID)
+        register_commands(self.tree, guild=guild)
+        try:
+            synced = await self.tree.sync(guild=guild)
+            logger.info(f"Synced {len(synced)} slash command(s) to guild {guild.id}")
+        except Exception:
+            logger.exception("Failed to sync slash commands; bot will run without them")
 
     async def on_ready(self) -> None:
         logger.info(f"Logged on as {self.user}!")

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -31,7 +31,7 @@ LINKS: dict[str, str] = {
 
 @app_commands.command(
     name="links",
-    description="Mostra os links importantes da comunidade do Waine",
+    description="Mostra os links importantes da Comunidade do Desempenho",
 )
 async def cmd_links(interaction: discord.Interaction) -> None:
     embed = discord.Embed(

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -1,0 +1,56 @@
+"""Slash commands registered on the bot's command tree.
+
+All slash commands live here so adding new ones is a one-stop change. The
+bot's ``setup_hook`` calls :func:`register_commands` and then
+``tree.sync(guild=...)`` (guild-scoped) so changes propagate instantly
+during development.
+
+To add a new command:
+1. Define it with ``@app_commands.command(...)`` here.
+2. Add ``tree.add_command(your_cmd, guild=guild)`` inside
+   :func:`register_commands`.
+3. Add a registration test in ``tests/test_slash.py``.
+"""
+
+import logging
+
+import discord
+from discord import app_commands
+
+logger = logging.getLogger(__name__)
+
+
+# Edit this dict to add/remove links. Keys are display names, values are URLs.
+LINKS: dict[str, str] = {
+    "YouTube": "https://www.youtube.com/@waine_jr",
+    "Discord": "https://discord.gg/RHuhFcfzyV",
+    "Instagram": "https://instagram.com/waine_jr",
+    "GitHub do Waine": "https://github.com/wainejr",
+}
+
+
+@app_commands.command(
+    name="links",
+    description="Mostra os links importantes da comunidade do Waine",
+)
+async def cmd_links(interaction: discord.Interaction) -> None:
+    embed = discord.Embed(
+        title="🔗 Links do Waine",
+        description="Confira os canais oficiais:",
+        color=discord.Color.blurple(),
+    )
+    for name, url in LINKS.items():
+        embed.add_field(name=name, value=url, inline=False)
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+def register_commands(
+    tree: app_commands.CommandTree,
+    guild: discord.abc.Snowflake | None = None,
+) -> None:
+    """Register all slash commands on ``tree``.
+
+    Pass ``guild=`` to scope commands to a single guild (instant sync,
+    great for dev). Pass ``None`` to register globally (~1h propagation).
+    """
+    tree.add_command(cmd_links, guild=guild)

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -1,0 +1,67 @@
+"""Tests for ``acelerado.slash`` — registration + response shape.
+
+We avoid instantiating the full ``AceleradoBot`` (which would try to
+connect to the gateway). A bare ``discord.Client`` is fine — its
+constructor doesn't open any sockets.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+from discord import app_commands
+
+from acelerado.slash import LINKS, cmd_links, register_commands
+
+
+def _build_tree() -> app_commands.CommandTree:
+    intents = discord.Intents.default()
+    client = discord.Client(intents=intents)
+    return app_commands.CommandTree(client)
+
+
+def test_register_links_command_globally():
+    tree = _build_tree()
+    register_commands(tree)
+
+    cmd = tree.get_command("links")
+    assert cmd is not None
+    assert cmd.name == "links"
+    assert cmd.description  # non-empty
+
+
+def test_register_links_command_guild_scoped():
+    tree = _build_tree()
+    guild = discord.Object(id=12345)
+    register_commands(tree, guild=guild)
+
+    # Guild-scoped commands aren't visible without passing guild=
+    assert tree.get_command("links") is None
+    assert tree.get_command("links", guild=guild) is not None
+
+
+async def test_links_command_sends_ephemeral_embed():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    # cmd_links is wrapped by @app_commands.command; invoke its callback directly.
+    await cmd_links.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs.get("ephemeral") is True
+
+    embed = kwargs.get("embed")
+    assert isinstance(embed, discord.Embed)
+    field_names = {f.name for f in embed.fields}
+    assert field_names == set(LINKS.keys())
+    field_values = {f.value for f in embed.fields}
+    assert field_values == set(LINKS.values())
+
+
+def test_links_dict_uses_https_urls():
+    """All links in the embed point to HTTPS — guard against accidental http://."""
+    for name, url in LINKS.items():
+        assert url.startswith("https://"), f"{name} has non-https URL: {url}"


### PR DESCRIPTION
## Resumo
- Habilita `app_commands` (slash commands) pela primeira vez no projeto.
- Adiciona `/links` como prova de conceito + base reutilizável pras outras issues que precisam de slash commands (#7, #10, #12, #13, #18).

## O que mudou
- **`acelerado/slash.py`** (novo): centraliza definição de slash commands. Expõe `register_commands(tree, guild=...)` pra ser chamada de uma vez no `setup_hook`.
- **`acelerado/bot.py`**: `setup_hook` agora chama `register_commands` e dá `tree.sync(guild=...)` guild-scoped (propagação instantânea, contra ~1h do sync global). Falhas no sync são logadas mas não derrubam o bot.
- **`/links`**: resposta ephemeral com embed listando YouTube, Discord, Instagram e GitHub.
- **`tests/test_slash.py`**: 4 testes cobrindo registro global, registro guild-scoped, shape da resposta (ephemeral + embed correto), e guard de URLs HTTPS.
- **Docs**: nova seção "Slash commands no Discord" no README; CLAUDE.md documenta a convenção pra adicionar novos comandos.

## Como testar localmente
\`\`\`sh
uv run pytest tests/test_slash.py -v   # 4 testes passam
uv run ruff check . && uv run mypy acelerado && uv run pytest
\`\`\`

Em produção, após o merge:
1. `acelerado run` (bot vai sincronizar os comandos no setup_hook).
2. No Discord, digite `/links` no canal — deve aparecer no autocomplete.
3. Resposta deve ser ephemeral (só você vê) com embed de 4 campos.

## Test plan
- [x] `pytest` 76/76 passando.
- [x] `ruff check`, `ruff format --check`, `mypy acelerado` clean.
- [ ] Smoke test no servidor real: `/links` aparece e responde corretamente.

Closes #9