### PR TITLE
feat: /update + acelerado update CLI (auto-update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,32 +117,29 @@ uv run acelerado run
 # tmux attach -t acelerado pra reanexar depois
 ```
 
-### Restart automático
+### Restart automático — `scripts/run.sh`
 
-Pra reiniciar automaticamente em caso de crash **ou** após `acelerado update` / `/update`, use um wrapper de loop:
-
-```sh
-while true; do uv run acelerado run; sleep 5; done
-```
-
-Ou, dentro do tmux:
+Pra reiniciar automaticamente em caso de crash **ou** após `acelerado update` / `/update`, use o supervisor incluso:
 
 ```sh
-tmux new -s acelerado 'while true; do uv run acelerado run; sleep 5; done'
+bash scripts/run.sh
 ```
 
-O bot sai com exit code **75** quando se atualiza com sucesso (convenção `EX_TEMPFAIL` do Unix). O loop acima não distingue exit codes — só restarta. Se quiser tratar exit 75 como "restart pedido" e qualquer outro como "crash com cooldown maior":
+Ou, recomendado, dentro de tmux:
 
 ```sh
-while true; do
-  uv run acelerado run
-  code=$?
-  case "$code" in
-    75) echo "[restart pedido pelo bot]"; sleep 1 ;;
-    *)  echo "[crash exit=$code]"; sleep 5 ;;
-  esac
-done
+tmux new -s acelerado 'bash scripts/run.sh'
+# Ctrl+B, D pra desanexar / tmux attach -t acelerado pra reanexar
 ```
+
+O script:
+
+- Restarta o bot quando ele sai com exit **75** (`EX_TEMPFAIL` — `acelerado update` ou `/update` pediu restart).
+- Restarta com **backoff exponencial** (2s → 4s → … → cap 60s) em caso de crash (exit ≠ 0/130/143). Evita loop tight de restart se o bot tiver bug fatal.
+- **Encerra o loop** com exit 0 (shutdown limpo via Ctrl+C → 130) ou em SIGTERM (143).
+- Loga cada evento com timestamp.
+
+Se quiser inspecionar o que o script faz, é tudo bash puro em `scripts/run.sh` (~30 linhas).
 
 Pra copiar um `token.pickle` renovado pra uma máquina remota (ex.: Raspberry Pi), há o utilitário `scripts/send_token.sh` (ajuste o host `home_rasp` pro seu `~/.ssh/config`).
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ uv sync
 |---------|-----------|
 | `/links` | Lista os canais/redes oficiais (resposta ephemeral, só você vê). |
 | `/sync` | (admin) Força a sincronização de cargos `Registradores` na hora — útil quando alguém acabou de virar membro pago no YouTube e não quer esperar o tick. |
+| `/update` | (admin) Faz `git pull` + `uv sync` e reinicia o bot via wrapper (exit code 75). Veja "Restart automático" abaixo. |
 
 Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
 
@@ -81,6 +82,7 @@ uv run acelerado --help
 | `acelerado monitor`           | Abre a TUI (`textual`) com contagem regressiva do token ao vivo e lista de anúncios recentes. |
 | `acelerado audit-members`     | Lista membros com o cargo `Registradores` que perderam o cargo do YouTube (tabela `rich`). |
 | `acelerado refresh-token`     | Faz backup de `token.pickle` e refaz o fluxo OAuth.                     |
+| `acelerado update`            | Faz `git pull --ff-only` + `uv sync --frozen`. Sai com exit 75 se atualizou; o wrapper externo deve restartar. |
 
 ### Logs
 
@@ -115,7 +117,9 @@ uv run acelerado run
 # tmux attach -t acelerado pra reanexar depois
 ```
 
-Pra reiniciar automaticamente em caso de crash, um one-liner também resolve:
+### Restart automático
+
+Pra reiniciar automaticamente em caso de crash **ou** após `acelerado update` / `/update`, use um wrapper de loop:
 
 ```sh
 while true; do uv run acelerado run; sleep 5; done
@@ -125,6 +129,19 @@ Ou, dentro do tmux:
 
 ```sh
 tmux new -s acelerado 'while true; do uv run acelerado run; sleep 5; done'
+```
+
+O bot sai com exit code **75** quando se atualiza com sucesso (convenção `EX_TEMPFAIL` do Unix). O loop acima não distingue exit codes — só restarta. Se quiser tratar exit 75 como "restart pedido" e qualquer outro como "crash com cooldown maior":
+
+```sh
+while true; do
+  uv run acelerado run
+  code=$?
+  case "$code" in
+    75) echo "[restart pedido pelo bot]"; sleep 1 ;;
+    *)  echo "[crash exit=$code]"; sleep 5 ;;
+  esac
+done
 ```
 
 Pra copiar um `token.pickle` renovado pra uma máquina remota (ex.: Raspberry Pi), há o utilitário `scripts/send_token.sh` (ajuste o host `home_rasp` pro seu `~/.ssh/config`).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ uv sync
    | `ACELERADO_TICK_SECONDS`        | (opcional) Período do loop, default `300`      |
    | `ACELERADO_LOG_LEVEL`           | (opcional) `DEBUG`/`INFO`/`WARNING`/…           |
    | `ACELERADO_AUTO_THREAD`         | (opcional) Auto-cria thread no anúncio de vídeo, default `true` |
+   | `DISCORD_WELCOME_CHANNEL_ID`    | (opcional) Canal pra mensagem de boas-vindas. Se `0`/vazio, tenta DM. |
 
 2. **Credenciais OAuth do Google** — copie o exemplo e substitua pelos valores da sua app:
 

--- a/acelerado/bot.py
+++ b/acelerado/bot.py
@@ -3,6 +3,7 @@ import logging
 import discord
 from discord.ext import commands, tasks
 
+from acelerado import welcome
 from acelerado.env import get_env
 from acelerado.slash import register_commands
 from acelerado.state import AceleradoState
@@ -42,6 +43,15 @@ class AceleradoBot(commands.Bot):
             )
         )
         logger.info("Updated presence!")
+
+    async def on_member_join(self, member: discord.Member) -> None:
+        try:
+            await welcome.handle_join(self, member)
+        except Exception as exc:
+            if self.state_handler is not None:
+                await self.state_handler.report_error("welcome", exc)
+            else:
+                logger.exception(f"welcome failed before state_handler ready: {exc}")
 
     async def on_error(self, event_method: str, /, *args, **kwargs) -> None:
         """Replace the default stderr dump with a proper log line.

--- a/acelerado/cli.py
+++ b/acelerado/cli.py
@@ -146,5 +146,34 @@ def monitor() -> None:
     run_monitor()
 
 
+@app.command()
+def update() -> None:
+    """Pull latest commits and re-sync deps. Exit code 75 on success → wrapper restarts."""
+    from acelerado.updater import EXIT_RESTART, apply_updates
+
+    result = apply_updates()
+
+    if result.status == "clean":
+        console.print("[yellow]⏸️  Nada pra atualizar[/]")
+        return
+    if result.status == "ok":
+        console.print(
+            f"[green]✅ Atualizado pra [bold]{result.short_head}[/bold] "
+            f"({len(result.commits)} commits)[/]"
+        )
+        for line in result.commits[:20]:
+            console.print(f"  • {line}")
+        console.print(
+            f"\n[bold]Saindo com exit {EXIT_RESTART}[/] — wrapper externo deve restartar."
+        )
+        raise typer.Exit(code=EXIT_RESTART)
+    if result.status == "conflict":
+        console.print(f"[red]❌ Conflito (working tree não fast-forwardável):[/]\n{result.message}")
+        raise typer.Exit(code=1)
+    # error
+    console.print(f"[red]❌ Falhou:[/] {result.message}")
+    raise typer.Exit(code=1)
+
+
 if __name__ == "__main__":
     app()

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -20,6 +20,10 @@ class EnvCfg(BaseSettings):
     # Whether new-video announcements automatically open a discussion thread.
     ACELERADO_AUTO_THREAD: bool = True
 
+    # Channel ID for ``on_member_join`` welcome messages. If 0/unset, the bot
+    # tries to DM the new member (which silently no-ops if DMs are blocked).
+    DISCORD_WELCOME_CHANNEL_ID: int = 0
+
 
 @lru_cache(maxsize=1)
 def get_env() -> EnvCfg:

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -81,6 +81,59 @@ async def cmd_sync(interaction: discord.Interaction) -> None:
     await interaction.followup.send(msg, ephemeral=True)
 
 
+@app_commands.command(
+    name="update",
+    description="(admin) Pull do código + uv sync; reinicia o bot via wrapper",
+)
+@app_commands.default_permissions(administrator=True)
+async def cmd_update(interaction: discord.Interaction) -> None:
+    import asyncio
+
+    from acelerado.updater import EXIT_RESTART, apply_updates
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    # apply_updates is sync (subprocess), run off the event loop.
+    result = await asyncio.to_thread(apply_updates)
+
+    if result.status == "clean":
+        await interaction.followup.send("⏸️ Nada pra atualizar.", ephemeral=True)
+        return
+    if result.status == "conflict":
+        await interaction.followup.send(
+            f"❌ Conflito impede o pull:\n```\n{result.message[:500]}\n```",
+            ephemeral=True,
+        )
+        return
+    if result.status == "error":
+        await interaction.followup.send(
+            f"❌ Erro: `{result.message[:500]}`",
+            ephemeral=True,
+        )
+        return
+
+    # status == "ok" — schedule restart after the response delivers.
+    commits_text = "\n".join(f"• {c}" for c in result.commits[:10])
+    if len(result.commits) > 10:
+        commits_text += f"\n• … (+{len(result.commits) - 10})"
+    await interaction.followup.send(
+        f"✅ Atualizado pra `{result.short_head}` ({len(result.commits)} commits)\n"
+        f"{commits_text}\n\n"
+        f"⚠️ Encerrando com exit {EXIT_RESTART} em 3s — wrapper deve restartar.",
+        ephemeral=True,
+    )
+    asyncio.create_task(_delayed_exit(EXIT_RESTART))
+
+
+async def _delayed_exit(code: int, delay_seconds: float = 3.0) -> None:
+    """Sleep briefly so the followup message ships, then exit hard."""
+    import asyncio
+    import os
+
+    await asyncio.sleep(delay_seconds)
+    logger.warning(f"Exiting with code {code} for wrapper-driven restart")
+    os._exit(code)
+
+
 def register_commands(
     tree: app_commands.CommandTree,
     guild: discord.abc.Snowflake | None = None,
@@ -92,3 +145,4 @@ def register_commands(
     """
     tree.add_command(cmd_links, guild=guild)
     tree.add_command(cmd_sync, guild=guild)
+    tree.add_command(cmd_update, guild=guild)

--- a/acelerado/updater.py
+++ b/acelerado/updater.py
@@ -47,9 +47,23 @@ class UpdateResult:
         return self.head[:7] if self.head else ""
 
 
-def _run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
-    """Thin wrapper over subprocess.run that always captures stdout/stderr."""
-    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(cwd))
+_DEFAULT_TIMEOUT = 60.0  # seconds
+
+
+def _run(cmd: list[str], cwd: Path, timeout: float = _DEFAULT_TIMEOUT) -> tuple[int, str, str]:
+    """Thin wrapper over subprocess.run that always captures stdout/stderr.
+
+    A timeout prevents a hung ``git fetch`` (network blip, creds prompt) from
+    pegging the bot — we'd rather fail fast and report ``error``. On timeout
+    we synthesize ``returncode=124`` (the convention from coreutils
+    ``timeout(1)``) so callers can tell it apart from a normal non-zero exit.
+    """
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=str(cwd), timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timed out after {timeout:.0f}s"
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
 
 

--- a/acelerado/updater.py
+++ b/acelerado/updater.py
@@ -1,0 +1,122 @@
+"""Self-update via ``git pull`` + ``uv sync``.
+
+Used by both ``acelerado update`` (CLI) and ``/update`` (admin slash).
+The functions here are pure orchestration over ``subprocess.run`` —
+``check_updates`` and ``apply_updates`` return a structured ``UpdateResult``
+that callers translate into Discord messages or terminal output.
+
+Design contract: **never raise**. Every failure mode is encoded in
+``UpdateResult.status`` so the consumers can react without try/except
+gymnastics. This is part of the fail-proof contract for the bot.
+
+Restart strategy: after a successful update, the process is expected to
+exit with **EX_TEMPFAIL (75)** so the wrapper (e.g.
+``while true; do uv run acelerado run; sleep 5; done``) restarts with
+the new code. The CLI subcommand exits 75 directly; the slash command
+schedules ``os._exit(75)`` a few seconds after sending the response.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+# Conventional exit code meaning "service unavailable; please retry" — used
+# here as the signal to the supervising wrapper that the process exited
+# cleanly because it wants to be restarted with new code.
+EXIT_RESTART = 75
+
+
+UpdateStatus = Literal["clean", "ok", "conflict", "error"]
+
+
+@dataclass
+class UpdateResult:
+    status: UpdateStatus
+    head: str = ""
+    commits: list[str] = field(default_factory=list)
+    message: str = ""
+
+    @property
+    def short_head(self) -> str:
+        return self.head[:7] if self.head else ""
+
+
+def _run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    """Thin wrapper over subprocess.run that always captures stdout/stderr."""
+    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(cwd))
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def check_updates(repo: Path | None = None) -> UpdateResult:
+    """Fetch from origin and report whether the local branch is behind.
+
+    Does **not** modify the working tree. Suitable for "is there an
+    update?" probes.
+    """
+    repo = repo or Path.cwd()
+
+    code, _, err = _run(["git", "fetch", "origin", "main"], cwd=repo)
+    if code != 0:
+        return UpdateResult(status="error", message=f"git fetch failed: {err}")
+
+    code, head, _ = _run(["git", "rev-parse", "HEAD"], cwd=repo)
+    if code != 0:
+        return UpdateResult(status="error", message="git rev-parse HEAD failed")
+
+    code, count_str, _ = _run(["git", "rev-list", "--count", "HEAD..origin/main"], cwd=repo)
+    if code != 0:
+        return UpdateResult(status="error", head=head, message="git rev-list failed")
+
+    count = int(count_str or "0")
+    if count == 0:
+        return UpdateResult(status="clean", head=head, message="Already up to date")
+
+    code, log_out, _ = _run(["git", "log", "HEAD..origin/main", "--oneline"], cwd=repo)
+    commits = log_out.splitlines() if log_out else []
+    return UpdateResult(
+        status="ok",
+        head=head,
+        commits=commits,
+        message=f"{count} new commit(s) on origin/main",
+    )
+
+
+def apply_updates(repo: Path | None = None) -> UpdateResult:
+    """Pull latest commits and re-sync deps. Status reflects what happened."""
+    repo = repo or Path.cwd()
+
+    pre = check_updates(repo)
+    if pre.status != "ok":
+        return pre  # clean / error — nothing to apply
+
+    code, _, err = _run(["git", "pull", "--ff-only", "origin", "main"], cwd=repo)
+    if code != 0:
+        return UpdateResult(
+            status="conflict",
+            head=pre.head,
+            commits=pre.commits,
+            message=err or "git pull failed (likely non-fast-forward)",
+        )
+
+    code, _, err = _run(["uv", "sync", "--frozen"], cwd=repo)
+    if code != 0:
+        return UpdateResult(
+            status="error",
+            head=pre.head,
+            commits=pre.commits,
+            message=f"uv sync failed: {err}",
+        )
+
+    code, head_after, _ = _run(["git", "rev-parse", "HEAD"], cwd=repo)
+    return UpdateResult(
+        status="ok",
+        head=head_after if code == 0 else pre.head,
+        commits=pre.commits,
+        message="Updated",
+    )

--- a/acelerado/welcome.py
+++ b/acelerado/welcome.py
@@ -1,0 +1,109 @@
+"""Welcome message handling for ``on_member_join``.
+
+Pure helpers (load, render, pick) are easy to unit-test. ``handle_join``
+is the only async piece — the bot's listener calls it and routes any
+escape through ``state.report_error("welcome", exc)``.
+
+Templates live in ``templates/welcome_messages.txt``: one line per
+saudação, ``#`` lines are comments. Placeholders supported:
+
+- ``{member}`` — mention (e.g. ``<@123>``)
+- ``{guild}`` — guild name
+- ``{channel_youtube}`` — canonical YouTube URL of the channel
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+from acelerado.env import get_env
+
+logger = logging.getLogger(__name__)
+
+WELCOME_TEMPLATE_PATH = Path("templates/welcome_messages.txt")
+YOUTUBE_CHANNEL_URL = "https://www.youtube.com/@waine_jr"
+
+DEFAULT_WELCOME = (
+    "Bem-vindo(a), {member}! Dá uma passada nas regras do servidor "
+    "e fique à vontade para se apresentar."
+)
+
+
+def load_welcome_messages(path: Path | None = None) -> list[str]:
+    """Read the template file, stripping blanks and ``#`` comments.
+
+    Returns ``[DEFAULT_WELCOME]`` if the file is missing or contains no
+    non-comment lines — callers never need to handle empty pools.
+    """
+    path = path or WELCOME_TEMPLATE_PATH
+    if not path.exists():
+        return [DEFAULT_WELCOME]
+
+    lines: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        lines.append(line)
+    return lines or [DEFAULT_WELCOME]
+
+
+def render_welcome(template: str, member: discord.Member, guild: discord.Guild | None) -> str:
+    return template.format(
+        member=member.mention,
+        guild=guild.name if guild is not None else "servidor",
+        channel_youtube=YOUTUBE_CHANNEL_URL,
+    )
+
+
+def pick_welcome(
+    member: discord.Member,
+    guild: discord.Guild | None,
+    *,
+    pool: list[str] | None = None,
+    rng: random.Random | None = None,
+) -> str:
+    """Pick a random welcome and render it for ``member``.
+
+    Pass ``rng=`` (a seeded ``random.Random``) for deterministic tests.
+    """
+    pool = pool if pool is not None else load_welcome_messages()
+    chooser = rng or random
+    template = chooser.choice(pool)
+    return render_welcome(template, member, guild)
+
+
+async def handle_join(bot: commands.Bot, member: discord.Member) -> None:
+    """Send a welcome message: configured channel first, fall back to DM.
+
+    Raises on unexpected failure; the caller (bot.on_member_join) wraps
+    with ``state.report_error("welcome", exc)``. ``discord.Forbidden``
+    on DM is treated as expected and silently logged — many users have
+    DMs blocked and that's fine.
+    """
+    if member.bot:
+        return  # don't welcome other bots
+
+    msg = pick_welcome(member, member.guild)
+
+    welcome_channel_id = get_env().DISCORD_WELCOME_CHANNEL_ID
+    if welcome_channel_id:
+        channel = bot.get_channel(welcome_channel_id)
+        if isinstance(channel, discord.abc.Messageable):
+            await channel.send(msg)
+            return
+        logger.warning(
+            f"DISCORD_WELCOME_CHANNEL_ID={welcome_channel_id} "
+            f"is not a sendable channel; falling back to DM"
+        )
+
+    # Fallback: DM. Forbidden = user blocked DMs — expected, not an error.
+    try:
+        await member.send(msg)
+    except discord.Forbidden:
+        logger.info(f"Cannot DM welcome to {member} — DMs blocked")

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# scripts/run.sh — supervisor wrapper for `acelerado run`.
+#
+# Restarts o bot quando:
+#   - sai com exit 75 (EX_TEMPFAIL — bot pediu restart, ex.: /update)
+#   - crasha com qualquer outro exit ≠ 0 (e ≠ 130 = Ctrl+C)
+#
+# Encerra o loop quando:
+#   - bot sai com exit 0 (shutdown limpo)
+#   - SIGINT (Ctrl+C → exit 130)
+#
+# Backoff em crash é exponencial: 2s → 4s → 8s → … → cap em 60s.
+# Restart pedido (exit 75) não tem backoff — queremos que volte rápido.
+#
+# Uso típico:
+#   tmux new -s acelerado 'bash scripts/run.sh'
+#   # depois: Ctrl+B, D pra desanexar / tmux attach -t acelerado
+
+set -uo pipefail
+
+# Vai pra raiz do repo independente de onde o script é chamado.
+cd "$(dirname "$0")/.." || exit 1
+
+BACKOFF_INITIAL=2
+BACKOFF_MAX=60
+backoff=$BACKOFF_INITIAL
+
+log() {
+    printf '[%s] [run.sh] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+trap 'log "received SIGINT; quitting"; exit 130' INT
+trap 'log "received SIGTERM; quitting"; exit 143' TERM
+
+while true; do
+    log "starting acelerado..."
+    uv run acelerado run
+    code=$?
+
+    case "$code" in
+        0)
+            log "clean exit; quitting"
+            exit 0
+            ;;
+        75)
+            log "restart requested by bot (exit 75)"
+            backoff=$BACKOFF_INITIAL
+            ;;
+        130 | 143)
+            log "interrupted (exit $code); quitting"
+            exit "$code"
+            ;;
+        *)
+            log "crash exit=$code; sleeping ${backoff}s before restart"
+            sleep "$backoff"
+            backoff=$(( backoff * 2 ))
+            (( backoff > BACKOFF_MAX )) && backoff=$BACKOFF_MAX
+            ;;
+    esac
+done

--- a/templates/welcome_messages.txt
+++ b/templates/welcome_messages.txt
@@ -1,0 +1,14 @@
+# Saudações pra novos membros — uma por linha.
+# Linhas começando com # são comentários (ignoradas).
+# Placeholders: {member} (mention), {guild}, {channel_youtube}.
+
+Bem-vindo(a), {member}! Já dá um `malloc` no canal de apresentação. 🚀
+{member} chegou em {guild} — esperamos que goste de assembly tanto quanto a gente.
+Olá {member}! Aqui a gente discute desempenho, baixo nível e cafezinho. ☕
+{member} entrou! Spoiler: o segredo é cache hit.
+Bem-vindo(a), {member}. Recomendo passar primeiro pelas regras antes de gastar ciclos.
+{member} chegou — espero que tenha trazido um perfil de chama. 🔥
+Salve {member}! Se quiser saber o que rola por aqui, dá uma olhada no canal: {channel_youtube}
+{member} ativado(a). Cuidado com cache misses no chat.
+Bem-vindo(a) ao {guild}, {member}! Aqui a gente otimiza loops e relacionamentos.
+{member}, mais um(a) na gangue do baixo nível. Sente em qualquer registrador livre.

--- a/templates/welcome_messages.txt
+++ b/templates/welcome_messages.txt
@@ -2,13 +2,13 @@
 # Linhas começando com # são comentários (ignoradas).
 # Placeholders: {member} (mention), {guild}, {channel_youtube}.
 
-Bem-vindo(a), {member}! Já dá um `malloc` no canal de apresentação. 🚀
-{member} chegou em {guild} — esperamos que goste de assembly tanto quanto a gente.
-Olá {member}! Aqui a gente discute desempenho, baixo nível e cafezinho. ☕
-{member} entrou! Spoiler: o segredo é cache hit.
-Bem-vindo(a), {member}. Recomendo passar primeiro pelas regras antes de gastar ciclos.
-{member} chegou — espero que tenha trazido um perfil de chama. 🔥
-Salve {member}! Se quiser saber o que rola por aqui, dá uma olhada no canal: {channel_youtube}
-{member} ativado(a). Cuidado com cache misses no chat.
-Bem-vindo(a) ao {guild}, {member}! Aqui a gente otimiza loops e relacionamentos.
-{member}, mais um(a) na gangue do baixo nível. Sente em qualquer registrador livre.
+Bem-vindo(a), {member}! Aqui a gente discute baixo nível, performance e cafezinho. ☕
+Bem-vindo(a), {member}. Aloca um tempinho pra se apresentar quando der.
+{member} chegou. Conta aí: C, Rust, Zig, ou outra?
+Bem-vindo(a), {member}. Dá uma passada nas regras quando puder.
+{member} entrou. Spoiler: o segredo é cache hit.
+E aí, {member}? Sente-se em qualquer registrador livre.
+Bem-vindo(a) ao {guild}, {member}! Se você curte performance, tá no lugar certo.
+{member} chegou. Se quiser saber o que rola por aqui: {channel_youtube}
+{member} chegou. Pega um café, sente onde quiser.
+Bem-vindo(a), {member}. Aqui é casa de quem perde sono com performance.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,3 +51,68 @@ def test_log_level_option_accepted(chdir_tmp):
 def test_invalid_log_level_fails(chdir_tmp):
     result = runner.invoke(app, ["--log-level", "XYZ", "status"])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# acelerado update
+# ---------------------------------------------------------------------------
+
+
+def test_update_command_clean(monkeypatch, chdir_tmp):
+    from acelerado import updater
+
+    monkeypatch.setattr(
+        updater,
+        "apply_updates",
+        lambda repo=None: updater.UpdateResult(status="clean", head="abc1234"),
+    )
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 0
+    assert "Nada pra atualizar" in result.stdout
+
+
+def test_update_command_ok_exits_with_restart_code(monkeypatch, chdir_tmp):
+    from acelerado import updater
+
+    monkeypatch.setattr(
+        updater,
+        "apply_updates",
+        lambda repo=None: updater.UpdateResult(
+            status="ok",
+            head="newhash1234567",
+            commits=["d2 c1", "c1 c0"],
+        ),
+    )
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == updater.EXIT_RESTART
+    assert "Atualizado" in result.stdout
+
+
+def test_update_command_conflict_exits_one(monkeypatch, chdir_tmp):
+    from acelerado import updater
+
+    monkeypatch.setattr(
+        updater,
+        "apply_updates",
+        lambda repo=None: updater.UpdateResult(status="conflict", message="bad merge"),
+    )
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 1
+    assert "Conflito" in result.stdout
+
+
+def test_update_command_error_exits_one(monkeypatch, chdir_tmp):
+    from acelerado import updater
+
+    monkeypatch.setattr(
+        updater,
+        "apply_updates",
+        lambda repo=None: updater.UpdateResult(status="error", message="something blew up"),
+    )
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 1
+    assert "Falhou" in result.stdout

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -7,6 +7,7 @@ constructor doesn't open any sockets.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
@@ -159,3 +160,107 @@ async def test_sync_command_handles_uninitialized_bot():
     interaction.response.send_message.assert_awaited_once()
     msg = interaction.response.send_message.await_args.args[0]
     assert "ainda não" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# /update admin command
+# ---------------------------------------------------------------------------
+
+
+def test_register_update_command():
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+
+    cmd = tree.get_command("update", guild=guild)
+    assert cmd is not None
+    assert cmd.default_permissions is not None
+    assert cmd.default_permissions.administrator is True
+
+
+def _make_update_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+async def test_update_command_clean_no_restart(monkeypatch):
+    from acelerado import slash, updater
+    from acelerado.slash import cmd_update
+
+    monkeypatch.setattr(
+        updater,
+        "apply_updates",
+        lambda repo=None: updater.UpdateResult(status="clean", message="up to date"),
+    )
+
+    # Sentinel: ensure _delayed_exit not scheduled on clean.
+    exit_calls = []
+    monkeypatch.setattr(slash, "_delayed_exit", lambda *a, **kw: exit_calls.append(a))
+
+    interaction = _make_update_interaction()
+    await cmd_update.callback(interaction)
+
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.args[0]
+    assert "Nada pra atualizar" in msg
+    assert exit_calls == []
+
+
+async def test_update_command_conflict_no_restart(monkeypatch):
+    from acelerado import slash, updater
+    from acelerado.slash import cmd_update
+
+    monkeypatch.setattr(
+        updater,
+        "apply_updates",
+        lambda repo=None: updater.UpdateResult(status="conflict", message="would be overwritten"),
+    )
+    exit_calls = []
+    monkeypatch.setattr(slash, "_delayed_exit", lambda *a, **kw: exit_calls.append(a))
+
+    interaction = _make_update_interaction()
+    await cmd_update.callback(interaction)
+
+    msg = interaction.followup.send.await_args.args[0]
+    assert "Conflito" in msg
+    assert exit_calls == []
+
+
+async def test_update_command_ok_schedules_restart(monkeypatch):
+    import asyncio
+
+    from acelerado import slash, updater
+    from acelerado.slash import cmd_update
+
+    monkeypatch.setattr(
+        updater,
+        "apply_updates",
+        lambda repo=None: updater.UpdateResult(
+            status="ok",
+            head="newhash1234",
+            commits=["c1 first commit", "c2 second commit"],
+            message="Updated",
+        ),
+    )
+
+    scheduled: list[Any] = []
+
+    async def fake_delayed_exit(code, delay_seconds=3.0):
+        scheduled.append((code, delay_seconds))
+
+    monkeypatch.setattr(slash, "_delayed_exit", fake_delayed_exit)
+
+    interaction = _make_update_interaction()
+    await cmd_update.callback(interaction)
+
+    msg = interaction.followup.send.await_args.args[0]
+    assert "Atualizado pra" in msg
+    assert "newhash" in msg
+    # A restart was scheduled
+    await asyncio.sleep(0)  # let the create_task run
+    assert len(scheduled) == 1
+    assert scheduled[0][0] == updater.EXIT_RESTART

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -69,6 +69,19 @@ def test_check_updates_with_pending_commits(mock_run, tmp_path: Path):
     assert len(result.commits) == 3
 
 
+def test_check_updates_timeout_is_reported_as_error(monkeypatch, tmp_path: Path):
+    """A hung git fetch should surface as status='error', not hang the bot."""
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 60))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = updater.check_updates(repo=tmp_path)
+    assert result.status == "error"
+    assert "timed out" in result.message.lower()
+
+
 def test_check_updates_fetch_failure(mock_run, tmp_path: Path):
     mock_run.queue.append(_proc(1, stderr="network unreachable"))
     result = updater.check_updates(repo=tmp_path)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,140 @@
+"""Tests for ``acelerado.updater`` — subprocess fully mocked."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from acelerado import updater
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    p = MagicMock()
+    p.returncode = returncode
+    p.stdout = stdout
+    p.stderr = stderr
+    return p
+
+
+@pytest.fixture
+def mock_run(monkeypatch: pytest.MonkeyPatch):
+    """Replace ``subprocess.run`` with a queue of canned responses keyed by argv prefix.
+
+    Each call dequeues the next matching response. Tests register responses by
+    sequence — first git command, second git command, etc.
+    """
+    calls: list[list[str]] = []
+    queue: list[MagicMock] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        calls.append(cmd)
+        if not queue:
+            raise AssertionError(f"Unexpected subprocess call: {cmd}")
+        return queue.pop(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return type("MockRun", (), {"calls": calls, "queue": queue})
+
+
+def test_check_updates_already_up_to_date(mock_run, tmp_path: Path):
+    mock_run.queue.extend(
+        [
+            _proc(0),  # git fetch
+            _proc(0, stdout="abc1234"),  # git rev-parse HEAD
+            _proc(0, stdout="0"),  # git rev-list --count
+        ]
+    )
+    result = updater.check_updates(repo=tmp_path)
+    assert result.status == "clean"
+    assert result.head == "abc1234"
+
+
+def test_check_updates_with_pending_commits(mock_run, tmp_path: Path):
+    mock_run.queue.extend(
+        [
+            _proc(0),
+            _proc(0, stdout="abc1234"),
+            _proc(0, stdout="3"),
+            _proc(0, stdout="d2 commit two\nc1 commit one\nb0 commit zero"),  # git log
+        ]
+    )
+    result = updater.check_updates(repo=tmp_path)
+    assert result.status == "ok"
+    assert result.head == "abc1234"
+    assert result.short_head == "abc1234"
+    assert len(result.commits) == 3
+
+
+def test_check_updates_fetch_failure(mock_run, tmp_path: Path):
+    mock_run.queue.append(_proc(1, stderr="network unreachable"))
+    result = updater.check_updates(repo=tmp_path)
+    assert result.status == "error"
+    assert "network unreachable" in result.message
+
+
+def test_apply_updates_clean_short_circuits(mock_run, tmp_path: Path):
+    mock_run.queue.extend(
+        [
+            _proc(0),
+            _proc(0, stdout="abc1234"),
+            _proc(0, stdout="0"),
+        ]
+    )
+    result = updater.apply_updates(repo=tmp_path)
+    assert result.status == "clean"
+    # Did not invoke git pull or uv sync
+    cmds_run = [c[0] + " " + c[1] for c in mock_run.calls if len(c) >= 2]
+    assert not any("pull" in c for c in cmds_run)
+
+
+def test_apply_updates_happy_path(mock_run, tmp_path: Path):
+    mock_run.queue.extend(
+        [
+            _proc(0),  # fetch
+            _proc(0, stdout="oldhead"),  # rev-parse HEAD (pre)
+            _proc(0, stdout="2"),  # rev-list --count
+            _proc(0, stdout="d2 two\nc1 one"),  # log
+            _proc(0),  # git pull --ff-only
+            _proc(0),  # uv sync --frozen
+            _proc(0, stdout="newheadhash"),  # rev-parse HEAD (post)
+        ]
+    )
+    result = updater.apply_updates(repo=tmp_path)
+    assert result.status == "ok"
+    assert result.head == "newheadhash"
+    assert len(result.commits) == 2
+
+
+def test_apply_updates_conflict(mock_run, tmp_path: Path):
+    mock_run.queue.extend(
+        [
+            _proc(0),
+            _proc(0, stdout="oldhead"),
+            _proc(0, stdout="1"),
+            _proc(0, stdout="d2 two"),
+            _proc(1, stderr="error: Your local changes would be overwritten"),
+        ]
+    )
+    result = updater.apply_updates(repo=tmp_path)
+    assert result.status == "conflict"
+    assert "would be overwritten" in result.message
+
+
+def test_apply_updates_uv_sync_fails(mock_run, tmp_path: Path):
+    mock_run.queue.extend(
+        [
+            _proc(0),
+            _proc(0, stdout="oldhead"),
+            _proc(0, stdout="1"),
+            _proc(0, stdout="d2 two"),
+            _proc(0),  # pull ok
+            _proc(1, stderr="resolution error"),  # uv sync fails
+        ]
+    )
+    result = updater.apply_updates(repo=tmp_path)
+    assert result.status == "error"
+    assert "resolution error" in result.message

--- a/tests/test_welcome.py
+++ b/tests/test_welcome.py
@@ -1,0 +1,179 @@
+"""Tests for ``acelerado.welcome``."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from acelerado import welcome
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_strips_comments_and_blanks(tmp_path: Path):
+    p = tmp_path / "msgs.txt"
+    p.write_text("# top comment\n\nBem-vindo, {member}!\n  \n# another comment\nOlá {member}\n")
+    assert welcome.load_welcome_messages(p) == ["Bem-vindo, {member}!", "Olá {member}"]
+
+
+def test_load_returns_default_when_file_missing(tmp_path: Path):
+    p = tmp_path / "missing.txt"
+    assert welcome.load_welcome_messages(p) == [welcome.DEFAULT_WELCOME]
+
+
+def test_load_returns_default_when_file_only_has_comments(tmp_path: Path):
+    p = tmp_path / "only_comments.txt"
+    p.write_text("# nothing here\n#\n# meta\n")
+    assert welcome.load_welcome_messages(p) == [welcome.DEFAULT_WELCOME]
+
+
+def test_real_pool_in_repo_loads_at_least_5_lines():
+    """Sanity: the shipped templates/welcome_messages.txt has a real pool."""
+    real = Path(__file__).resolve().parent.parent / "templates" / "welcome_messages.txt"
+    if not real.exists():
+        pytest.skip("templates/welcome_messages.txt not present in this checkout")
+    msgs = welcome.load_welcome_messages(real)
+    assert len(msgs) >= 5
+    # All shipped templates use known placeholders only
+    for m in msgs:
+        m.format(member="<@1>", guild="g", channel_youtube="https://x")
+
+
+# ---------------------------------------------------------------------------
+# Render + pick
+# ---------------------------------------------------------------------------
+
+
+def _fake_member(name: str = "alice", member_id: int = 99) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.name = name
+    m.id = member_id
+    m.mention = f"<@{member_id}>"
+    m.bot = False
+    m.send = AsyncMock()
+    return m
+
+
+def _fake_guild(name: str = "Guildão") -> MagicMock:
+    g = MagicMock(spec=discord.Guild)
+    g.name = name
+    return g
+
+
+def test_render_substitutes_all_placeholders():
+    member = _fake_member()
+    guild = _fake_guild()
+    rendered = welcome.render_welcome(
+        "Olá {member}, bem-vindo a {guild}! Canal: {channel_youtube}",
+        member,
+        guild,
+    )
+    assert "<@99>" in rendered
+    assert "Guildão" in rendered
+    assert welcome.YOUTUBE_CHANNEL_URL in rendered
+
+
+def test_pick_is_deterministic_with_seeded_rng():
+    pool = ["A {member}", "B {member}", "C {member}", "D {member}"]
+    member = _fake_member()
+    guild = _fake_guild()
+
+    rng = random.Random(42)
+    first = welcome.pick_welcome(member, guild, pool=pool, rng=rng)
+
+    rng = random.Random(42)  # same seed
+    second = welcome.pick_welcome(member, guild, pool=pool, rng=rng)
+
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# handle_join — channel/DM branches
+# ---------------------------------------------------------------------------
+
+
+def _fake_bot_with_channel(channel) -> MagicMock:
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+    return bot
+
+
+async def test_handle_join_posts_to_configured_channel(monkeypatch):
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "12345")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.send = AsyncMock()
+    bot = _fake_bot_with_channel(channel)
+
+    member = _fake_member()
+    member.guild = _fake_guild()
+    await welcome.handle_join(bot, member)
+
+    channel.send.assert_awaited_once()
+    member.send.assert_not_awaited()
+
+
+async def test_handle_join_falls_back_to_dm_when_channel_id_zero(monkeypatch):
+    # default ACELERADO env doesn't set welcome channel
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "0")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = _fake_bot_with_channel(None)
+    member = _fake_member()
+    member.guild = _fake_guild()
+    await welcome.handle_join(bot, member)
+
+    member.send.assert_awaited_once()
+
+
+async def test_handle_join_dm_blocked_is_silently_logged(monkeypatch, caplog):
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "0")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = _fake_bot_with_channel(None)
+    member = _fake_member()
+    member.guild = _fake_guild()
+    member.send.side_effect = discord.Forbidden(MagicMock(status=403), "DMs disabled")
+
+    # Must not raise
+    with caplog.at_level("INFO", logger="acelerado.welcome"):
+        await welcome.handle_join(bot, member)
+    assert any("DMs blocked" in r.message for r in caplog.records)
+
+
+async def test_handle_join_skips_other_bots():
+    bot = _fake_bot_with_channel(None)
+    member = _fake_member()
+    member.bot = True
+    member.guild = _fake_guild()
+
+    await welcome.handle_join(bot, member)
+    member.send.assert_not_awaited()
+
+
+async def test_handle_join_falls_back_when_channel_id_set_but_invalid(monkeypatch):
+    """If the configured channel id resolves to None or non-Messageable, fall back to DM."""
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "999")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = _fake_bot_with_channel(None)  # get_channel returns None
+    member = _fake_member()
+    member.guild = _fake_guild()
+    await welcome.handle_join(bot, member)
+
+    member.send.assert_awaited_once()


### PR DESCRIPTION
**Stacked on #21.** Merge #20 → #21 → this.

## Resumo
Implementa #18: \`git pull\` + \`uv sync\` automatizados, com restart via wrapper externo (convenção exit 75 / \`EX_TEMPFAIL\`).

## Arquitetura
Toda a lógica de orquestração vive em \`acelerado/updater.py\` — função pura sobre \`subprocess.run\`. CLI e slash compartilham:

\`\`\`
apply_updates() -> UpdateResult
  ├─ check_updates() (fetch + rev-list)
  ├─ git pull --ff-only        (se há commits novos)
  ├─ uv sync --frozen          (se pull deu certo)
  └─ rev-parse HEAD            (head após pull)
\`\`\`

\`UpdateResult.status\` cobre todo desfecho: \`clean\` | \`ok\` | \`conflict\` | \`error\`. Nunca raise — parte do contrato fail-proof.

## CLI: \`acelerado update\`
- Exit 0 se \`clean\`, **75** se \`ok\` (wrapper deve restartar), 1 se \`conflict\` ou \`error\`.
- Output via \`rich.console\` com cores e listagem dos commits novos.

## Slash: \`/update\` (admin)
- Defer ephemeral, roda \`apply_updates\` em \`asyncio.to_thread\` (subprocess é blocking).
- Em sucesso: posta resumo + agenda \`os._exit(75)\` 3s depois (tempo de delivery do followup).
- Não-sucesso: mensagem ephemeral correspondente, processo continua rodando.

## Wrapper recomendado
README ganha duas variantes — uma simples (\`while true; do … sleep 5; done\`) e uma que distingue exit 75 (restart pedido) de outros códigos (crash, cooldown maior).

## Test plan
- [x] \`pytest\` 102/102 (87 → 102: 6 testes do updater + 4 testes do slash + 4 do CLI + 1 de registro de comando).
- [x] \`ruff check\`, \`ruff format --check\`, \`mypy\` clean.
- [ ] Smoke local: \`uv run acelerado update\` num repo limpo (\`clean\`) e num repo atrás (\`ok\` + exit 75).
- [ ] Smoke produção: \`/update\` quando há commit novo na main; verificar que a mensagem aparece e o tmux reentra com a versão nova.
- [ ] Cuidado: se a máquina remota não tiver \`uv\` no PATH do bot, vai falhar. README assume que sim.

Closes #18