### PR TITLE
feat: welcome message on member join with random pool (#8 + #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ uv sync
    | `ACELERADO_TICK_SECONDS`        | (opcional) Período do loop, default `300`      |
    | `ACELERADO_LOG_LEVEL`           | (opcional) `DEBUG`/`INFO`/`WARNING`/…           |
    | `ACELERADO_AUTO_THREAD`         | (opcional) Auto-cria thread no anúncio de vídeo, default `true` |
+   | `DISCORD_WELCOME_CHANNEL_ID`    | (opcional) Canal pra mensagem de boas-vindas. Se `0`/vazio, tenta DM. |
 
 2. **Credenciais OAuth do Google** — copie o exemplo e substitua pelos valores da sua app:
 

--- a/acelerado/bot.py
+++ b/acelerado/bot.py
@@ -3,6 +3,7 @@ import logging
 import discord
 from discord.ext import commands, tasks
 
+from acelerado import welcome
 from acelerado.env import get_env
 from acelerado.slash import register_commands
 from acelerado.state import AceleradoState
@@ -42,6 +43,15 @@ class AceleradoBot(commands.Bot):
             )
         )
         logger.info("Updated presence!")
+
+    async def on_member_join(self, member: discord.Member) -> None:
+        try:
+            await welcome.handle_join(self, member)
+        except Exception as exc:
+            if self.state_handler is not None:
+                await self.state_handler.report_error("welcome", exc)
+            else:
+                logger.exception(f"welcome failed before state_handler ready: {exc}")
 
     async def on_error(self, event_method: str, /, *args, **kwargs) -> None:
         """Replace the default stderr dump with a proper log line.

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -20,6 +20,10 @@ class EnvCfg(BaseSettings):
     # Whether new-video announcements automatically open a discussion thread.
     ACELERADO_AUTO_THREAD: bool = True
 
+    # Channel ID for ``on_member_join`` welcome messages. If 0/unset, the bot
+    # tries to DM the new member (which silently no-ops if DMs are blocked).
+    DISCORD_WELCOME_CHANNEL_ID: int = 0
+
 
 @lru_cache(maxsize=1)
 def get_env() -> EnvCfg:

--- a/acelerado/welcome.py
+++ b/acelerado/welcome.py
@@ -1,0 +1,109 @@
+"""Welcome message handling for ``on_member_join``.
+
+Pure helpers (load, render, pick) are easy to unit-test. ``handle_join``
+is the only async piece — the bot's listener calls it and routes any
+escape through ``state.report_error("welcome", exc)``.
+
+Templates live in ``templates/welcome_messages.txt``: one line per
+saudação, ``#`` lines are comments. Placeholders supported:
+
+- ``{member}`` — mention (e.g. ``<@123>``)
+- ``{guild}`` — guild name
+- ``{channel_youtube}`` — canonical YouTube URL of the channel
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+from acelerado.env import get_env
+
+logger = logging.getLogger(__name__)
+
+WELCOME_TEMPLATE_PATH = Path("templates/welcome_messages.txt")
+YOUTUBE_CHANNEL_URL = "https://www.youtube.com/@waine_jr"
+
+DEFAULT_WELCOME = (
+    "Bem-vindo(a), {member}! Dá uma passada nas regras do servidor "
+    "e fique à vontade para se apresentar."
+)
+
+
+def load_welcome_messages(path: Path | None = None) -> list[str]:
+    """Read the template file, stripping blanks and ``#`` comments.
+
+    Returns ``[DEFAULT_WELCOME]`` if the file is missing or contains no
+    non-comment lines — callers never need to handle empty pools.
+    """
+    path = path or WELCOME_TEMPLATE_PATH
+    if not path.exists():
+        return [DEFAULT_WELCOME]
+
+    lines: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        lines.append(line)
+    return lines or [DEFAULT_WELCOME]
+
+
+def render_welcome(template: str, member: discord.Member, guild: discord.Guild | None) -> str:
+    return template.format(
+        member=member.mention,
+        guild=guild.name if guild is not None else "servidor",
+        channel_youtube=YOUTUBE_CHANNEL_URL,
+    )
+
+
+def pick_welcome(
+    member: discord.Member,
+    guild: discord.Guild | None,
+    *,
+    pool: list[str] | None = None,
+    rng: random.Random | None = None,
+) -> str:
+    """Pick a random welcome and render it for ``member``.
+
+    Pass ``rng=`` (a seeded ``random.Random``) for deterministic tests.
+    """
+    pool = pool if pool is not None else load_welcome_messages()
+    chooser = rng or random
+    template = chooser.choice(pool)
+    return render_welcome(template, member, guild)
+
+
+async def handle_join(bot: commands.Bot, member: discord.Member) -> None:
+    """Send a welcome message: configured channel first, fall back to DM.
+
+    Raises on unexpected failure; the caller (bot.on_member_join) wraps
+    with ``state.report_error("welcome", exc)``. ``discord.Forbidden``
+    on DM is treated as expected and silently logged — many users have
+    DMs blocked and that's fine.
+    """
+    if member.bot:
+        return  # don't welcome other bots
+
+    msg = pick_welcome(member, member.guild)
+
+    welcome_channel_id = get_env().DISCORD_WELCOME_CHANNEL_ID
+    if welcome_channel_id:
+        channel = bot.get_channel(welcome_channel_id)
+        if isinstance(channel, discord.abc.Messageable):
+            await channel.send(msg)
+            return
+        logger.warning(
+            f"DISCORD_WELCOME_CHANNEL_ID={welcome_channel_id} "
+            f"is not a sendable channel; falling back to DM"
+        )
+
+    # Fallback: DM. Forbidden = user blocked DMs — expected, not an error.
+    try:
+        await member.send(msg)
+    except discord.Forbidden:
+        logger.info(f"Cannot DM welcome to {member} — DMs blocked")

--- a/templates/welcome_messages.txt
+++ b/templates/welcome_messages.txt
@@ -1,0 +1,14 @@
+# Saudações pra novos membros — uma por linha.
+# Linhas começando com # são comentários (ignoradas).
+# Placeholders: {member} (mention), {guild}, {channel_youtube}.
+
+Bem-vindo(a), {member}! Já dá um `malloc` no canal de apresentação. 🚀
+{member} chegou em {guild} — esperamos que goste de assembly tanto quanto a gente.
+Olá {member}! Aqui a gente discute desempenho, baixo nível e cafezinho. ☕
+{member} entrou! Spoiler: o segredo é cache hit.
+Bem-vindo(a), {member}. Recomendo passar primeiro pelas regras antes de gastar ciclos.
+{member} chegou — espero que tenha trazido um perfil de chama. 🔥
+Salve {member}! Se quiser saber o que rola por aqui, dá uma olhada no canal: {channel_youtube}
+{member} ativado(a). Cuidado com cache misses no chat.
+Bem-vindo(a) ao {guild}, {member}! Aqui a gente otimiza loops e relacionamentos.
+{member}, mais um(a) na gangue do baixo nível. Sente em qualquer registrador livre.

--- a/templates/welcome_messages.txt
+++ b/templates/welcome_messages.txt
@@ -2,13 +2,13 @@
 # Linhas começando com # são comentários (ignoradas).
 # Placeholders: {member} (mention), {guild}, {channel_youtube}.
 
-Bem-vindo(a), {member}! Já dá um `malloc` no canal de apresentação. 🚀
-{member} chegou em {guild} — esperamos que goste de assembly tanto quanto a gente.
-Olá {member}! Aqui a gente discute desempenho, baixo nível e cafezinho. ☕
-{member} entrou! Spoiler: o segredo é cache hit.
-Bem-vindo(a), {member}. Recomendo passar primeiro pelas regras antes de gastar ciclos.
-{member} chegou — espero que tenha trazido um perfil de chama. 🔥
-Salve {member}! Se quiser saber o que rola por aqui, dá uma olhada no canal: {channel_youtube}
-{member} ativado(a). Cuidado com cache misses no chat.
-Bem-vindo(a) ao {guild}, {member}! Aqui a gente otimiza loops e relacionamentos.
-{member}, mais um(a) na gangue do baixo nível. Sente em qualquer registrador livre.
+Bem-vindo(a), {member}! Aqui a gente discute baixo nível, performance e cafezinho. ☕
+Bem-vindo(a), {member}. Aloca um tempinho pra se apresentar quando der.
+{member} chegou. Conta aí: C, Rust, Zig, ou outra?
+Bem-vindo(a), {member}. Dá uma passada nas regras quando puder.
+{member} entrou. Spoiler: o segredo é cache hit.
+E aí, {member}? Sente-se em qualquer registrador livre.
+Bem-vindo(a) ao {guild}, {member}! Se você curte performance, tá no lugar certo.
+{member} chegou. Se quiser saber o que rola por aqui: {channel_youtube}
+{member} chegou. Pega um café, sente onde quiser.
+Bem-vindo(a), {member}. Aqui é casa de quem perde sono com performance.

--- a/tests/test_welcome.py
+++ b/tests/test_welcome.py
@@ -1,0 +1,179 @@
+"""Tests for ``acelerado.welcome``."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from acelerado import welcome
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_strips_comments_and_blanks(tmp_path: Path):
+    p = tmp_path / "msgs.txt"
+    p.write_text("# top comment\n\nBem-vindo, {member}!\n  \n# another comment\nOlá {member}\n")
+    assert welcome.load_welcome_messages(p) == ["Bem-vindo, {member}!", "Olá {member}"]
+
+
+def test_load_returns_default_when_file_missing(tmp_path: Path):
+    p = tmp_path / "missing.txt"
+    assert welcome.load_welcome_messages(p) == [welcome.DEFAULT_WELCOME]
+
+
+def test_load_returns_default_when_file_only_has_comments(tmp_path: Path):
+    p = tmp_path / "only_comments.txt"
+    p.write_text("# nothing here\n#\n# meta\n")
+    assert welcome.load_welcome_messages(p) == [welcome.DEFAULT_WELCOME]
+
+
+def test_real_pool_in_repo_loads_at_least_5_lines():
+    """Sanity: the shipped templates/welcome_messages.txt has a real pool."""
+    real = Path(__file__).resolve().parent.parent / "templates" / "welcome_messages.txt"
+    if not real.exists():
+        pytest.skip("templates/welcome_messages.txt not present in this checkout")
+    msgs = welcome.load_welcome_messages(real)
+    assert len(msgs) >= 5
+    # All shipped templates use known placeholders only
+    for m in msgs:
+        m.format(member="<@1>", guild="g", channel_youtube="https://x")
+
+
+# ---------------------------------------------------------------------------
+# Render + pick
+# ---------------------------------------------------------------------------
+
+
+def _fake_member(name: str = "alice", member_id: int = 99) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.name = name
+    m.id = member_id
+    m.mention = f"<@{member_id}>"
+    m.bot = False
+    m.send = AsyncMock()
+    return m
+
+
+def _fake_guild(name: str = "Guildão") -> MagicMock:
+    g = MagicMock(spec=discord.Guild)
+    g.name = name
+    return g
+
+
+def test_render_substitutes_all_placeholders():
+    member = _fake_member()
+    guild = _fake_guild()
+    rendered = welcome.render_welcome(
+        "Olá {member}, bem-vindo a {guild}! Canal: {channel_youtube}",
+        member,
+        guild,
+    )
+    assert "<@99>" in rendered
+    assert "Guildão" in rendered
+    assert welcome.YOUTUBE_CHANNEL_URL in rendered
+
+
+def test_pick_is_deterministic_with_seeded_rng():
+    pool = ["A {member}", "B {member}", "C {member}", "D {member}"]
+    member = _fake_member()
+    guild = _fake_guild()
+
+    rng = random.Random(42)
+    first = welcome.pick_welcome(member, guild, pool=pool, rng=rng)
+
+    rng = random.Random(42)  # same seed
+    second = welcome.pick_welcome(member, guild, pool=pool, rng=rng)
+
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# handle_join — channel/DM branches
+# ---------------------------------------------------------------------------
+
+
+def _fake_bot_with_channel(channel) -> MagicMock:
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+    return bot
+
+
+async def test_handle_join_posts_to_configured_channel(monkeypatch):
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "12345")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.send = AsyncMock()
+    bot = _fake_bot_with_channel(channel)
+
+    member = _fake_member()
+    member.guild = _fake_guild()
+    await welcome.handle_join(bot, member)
+
+    channel.send.assert_awaited_once()
+    member.send.assert_not_awaited()
+
+
+async def test_handle_join_falls_back_to_dm_when_channel_id_zero(monkeypatch):
+    # default ACELERADO env doesn't set welcome channel
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "0")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = _fake_bot_with_channel(None)
+    member = _fake_member()
+    member.guild = _fake_guild()
+    await welcome.handle_join(bot, member)
+
+    member.send.assert_awaited_once()
+
+
+async def test_handle_join_dm_blocked_is_silently_logged(monkeypatch, caplog):
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "0")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = _fake_bot_with_channel(None)
+    member = _fake_member()
+    member.guild = _fake_guild()
+    member.send.side_effect = discord.Forbidden(MagicMock(status=403), "DMs disabled")
+
+    # Must not raise
+    with caplog.at_level("INFO", logger="acelerado.welcome"):
+        await welcome.handle_join(bot, member)
+    assert any("DMs blocked" in r.message for r in caplog.records)
+
+
+async def test_handle_join_skips_other_bots():
+    bot = _fake_bot_with_channel(None)
+    member = _fake_member()
+    member.bot = True
+    member.guild = _fake_guild()
+
+    await welcome.handle_join(bot, member)
+    member.send.assert_not_awaited()
+
+
+async def test_handle_join_falls_back_when_channel_id_set_but_invalid(monkeypatch):
+    """If the configured channel id resolves to None or non-Messageable, fall back to DM."""
+    monkeypatch.setenv("DISCORD_WELCOME_CHANNEL_ID", "999")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = _fake_bot_with_channel(None)  # get_channel returns None
+    member = _fake_member()
+    member.guild = _fake_guild()
+    await welcome.handle_join(bot, member)
+
+    member.send.assert_awaited_once()


### PR DESCRIPTION
**Stacked on #22.** Merge order: #20 → #21 → #22 → this.

## Resumo
Implementa #8 (mensagem de boas-vindas pra novos membros) + #19 (pool com sorteio aleatório) numa PR só — compartilham o código de loading dos templates.

## Arquivos
- **`acelerado/welcome.py`** (novo) — \`load_welcome_messages\`, \`render_welcome\`, \`pick_welcome\`, \`handle_join\`. As três primeiras são puras e testáveis sem rede.
- **`templates/welcome_messages.txt`** (novo) — 10 saudações iniciais no tom do canal (low-level + cafezinho). Comunidade pode estender via PR (\`good first issue\` da #19).
- **`acelerado/bot.py`** — \`on_member_join\` listener que chama \`welcome.handle_join\` e rota erros via \`state.report_error(\"welcome\", exc)\`.
- **`acelerado/env.py`** — \`DISCORD_WELCOME_CHANNEL_ID: int = 0\` opcional.

## Comportamento
1. Se \`DISCORD_WELCOME_CHANNEL_ID\` setado e resolve pra um canal sendable → posta lá.
2. Senão (ou se o canal sumiu/inválido) → tenta DM.
3. \`Forbidden\` na DM (DMs bloqueadas) → log INFO, não propaga.
4. Bots não recebem mensagem (skip imediato).

Placeholders suportados: \`{member}\`, \`{guild}\`, \`{channel_youtube}\`.

## Test plan
- [x] \`pytest\` 113/113 (102 → 113).
- [x] \`ruff\`, \`mypy\` clean.
- [ ] Smoke: entrar no servidor com user de teste, verificar que cai mensagem aleatória no canal/DM.
- [ ] Smoke: configurar canal inválido em \`DISCORD_WELCOME_CHANNEL_ID\`; bot deve cair pra DM.

Closes #8
Closes #19