### PR TITLE
feat: live reminder for scheduled YouTube livestreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ published.txt
 last_tick.txt
 metrics.json
 metrics.json.tmp
+live_reminders.txt
 
 # Created by https://www.toptal.com/developers/gitignore/api/python
 # Edit at https://www.toptal.com/developers/gitignore?templates=python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Como contribuir
+
+Obrigado por considerar contribuir com o Acelerado! Esse guia é o caminho rápido.
+
+## Pré-requisitos
+
+- **Python 3.11+**
+- [`uv`](https://docs.astral.sh/uv/) — `pip install -U uv`
+- Conta no [Discord Developer Portal](https://discord.com/developers/applications) para criar um bot de testes.
+- (Opcional) Credenciais OAuth do Google + chave da YouTube Data API v3 — só se for mexer com a parte de YouTube.
+
+## Setup local
+
+```sh
+git clone https://github.com/seu-usuario/discord.git
+cd discord
+uv sync                                 # instala deps + dev deps
+cp .example.env .env                    # depois edite com seus valores
+cp credentials.example.json credentials.json   # depois cole o JSON da app Google
+```
+
+Veja a seção **"Como obter credenciais"** no [`README.md`](./README.md) pra um passo-a-passo de Discord + Google Cloud.
+
+## Workflow de contribuição
+
+1. **Branch**: `feat/<descrição-curta>`, `fix/<bug>`, `docs/<o-que>`.
+2. **Antes de commitar**, rode o "CI local":
+
+   ```sh
+   uv run ruff check . && \
+   uv run ruff format --check . && \
+   uv run mypy acelerado && \
+   uv run pytest
+   ```
+
+   Se algo falhar, ajusta. CI no GitHub Actions roda exatamente isso em PRs/pushes pra `main`.
+3. **Commit**: mensagem descritiva, idealmente referenciando a issue (`closes #N` no body fecha automaticamente no merge).
+4. **PR**: descrição clara, checklist de smoke tests, espera review.
+
+## Convenções
+
+### Idioma
+- **UI / Discord**: PT-BR (mensagens, role names, comandos).
+- **Código** (variáveis, funções, comentários, docstrings, mensagens de log): inglês.
+
+### Logging
+Cada módulo declara seu logger:
+```python
+import logging
+logger = logging.getLogger(__name__)
+```
+Não importe um `logger` compartilhado de `acelerado.log` — o handler global é configurado uma vez via `setup_logging()` no callback do typer.
+
+### Testes
+Tudo offline. Discord e Google YouTube API são mockados via fixtures de `tests/conftest.py`:
+- `fake_bot`, `fake_guild` — stand-ins de `commands.Bot` / `discord.Guild`.
+- `make_video_fn`, `make_playlist_item_fn` — builders de payload.
+- `_fake_youtube_client()` em `tests/test_youtube.py` — mock encadeável da Google API.
+
+Nunca abra socket, nunca dispara OAuth.
+
+### Contrato fail-proof
+Toda corotina dentro de um tick (passos do `event_loop`) **não deve raise** — falhas devem cair em `state.report_error("contexto", exc)`, que loga local e posta no canal de log do Discord (com cooldown de 10 min). O guard externo em `bot.event_loop_task` é a última rede; não confie nele pra lógica.
+
+Veja `CLAUDE.md` ("Fail-proof contract") pra detalhes.
+
+### Slash commands
+Vão em `acelerado/slash.py` ou módulos próprios. Pra adicionar um novo:
+
+1. Definir com `@app_commands.command(...)`.
+2. `tree.add_command(seu_cmd, guild=guild)` no `register_commands`.
+3. Teste de registro em `tests/test_slash.py` (ou módulo afim).
+4. Documentar no README.
+
+## Tarefas iniciais
+
+Issues marcadas com **`good first issue`** são bem delimitadas e ótimas pra começar — geralmente self-contained, com critérios de aceite claros e cobertura de teste pequena.
+
+## Contexto profundo
+
+[`CLAUDE.md`](./CLAUDE.md) tem o overview arquitetural — stack, layout, contratos, e gotchas. Vale a leitura antes de mexer em algo grande.
+
+## Reportando bugs
+
+Issue com:
+- **O que aconteceu** vs. o que era esperado.
+- **Como reproduzir** (passos + comando, se possível).
+- **Stack trace** completo. Rodar com `--log-level DEBUG` ajuda muito.
+- Versão do Python, do bot (commit hash) e SO.
+
+## Código de conduta
+
+Seja gentil. Aqui é uma comunidade de gente curiosa que gosta de programação de baixo nível e cafezinho.
+
+Obrigado!

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ uv sync
 | `/report` | Reportar uma mensagem aos mods. Recebe link da mensagem (Copy Message Link) + motivo. Rate-limit de 3 reports / 10min por usuário. |
 | `/preview-summary` | (admin) Posta o rascunho do resumo semanal **agora** no canal de review (botões pra Aprovar / Editar / Descartar). |
 | `/preview-stale` | (admin) Posta a lista de apoiadores stale **agora** no canal de mods. |
-| `/godbolt` | Gera link do [Compiler Explorer](https://godbolt.org) com seu código pré-carregado. Suporta C, C++, Rust, Zig, Go. |
+| `/godbolt` | Gera link do [Compiler Explorer](https://godbolt.org) com seu código pré-carregado. Suporta C, C++, Rust, Zig, Go, Python, JavaScript, Java, Haskell, Odin. |
 
 Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,53 @@ uv sync
 
    Na primeira execução que precisar da API do YouTube (por ex. `acelerado run` ou `acelerado refresh-token`), o navegador abrirá para consentimento e o token será salvo em `token.pickle`.
 
+## Como obter as credenciais
+
+Passo-a-passo pra preencher tudo do zero. Se você já tem app de bot no Discord e projeto no Google Cloud, pula direto pra "Pegando os IDs do servidor" no fim.
+
+### Discord — bot + token + intent
+
+1. Acesse o [Discord Developer Portal](https://discord.com/developers/applications) e clique em **New Application**.
+2. Dê um nome, aceite os termos.
+3. Na navegação à esquerda, vá em **Bot**:
+   - Clique em **Reset Token** e copie o valor — vira o seu `DISCORD_TOKEN` no `.env`. **Esse token nunca deve ser compartilhado nem commitado.**
+   - Em **Privileged Gateway Intents**, ligue **Server Members Intent** (necessário pra sincronização de cargos).
+4. Em **OAuth2 → URL Generator** (menu esquerdo):
+   - **Scopes**: marque `bot` e `applications.commands`.
+   - **Bot Permissions**: marque pelo menos `Send Messages`, `Manage Messages` (pra anti-spam de invites), `Manage Roles` (pra adicionar `Registradores`), `Read Messages/View Channels`, `Create Public Threads` (pra auto-thread em anúncios).
+   - Copie a URL gerada e abra num navegador logado na sua conta Discord. Selecione o servidor onde o bot vai entrar e autorize.
+
+### Google Cloud — OAuth + API key
+
+1. Acesse o [Google Cloud Console](https://console.cloud.google.com/) e crie (ou selecione) um projeto.
+2. Em **APIs e Serviços → Biblioteca**, busque **YouTube Data API v3** e clique em **Ativar**.
+3. **Tela de consentimento OAuth**: configure como "Externo" (mesmo se for só pra você), preencha nome do app e e-mail de suporte. Em "Usuários de teste", adicione o e-mail do dono do canal do YouTube.
+4. **APIs e Serviços → Credenciais**:
+   - **Criar credenciais → ID do cliente OAuth** → tipo de aplicativo "App para computador". Baixe o JSON e renomeie pra `credentials.json` na raiz do repo.
+   - **Criar credenciais → Chave de API** → copia a chave; vira o `YOUTUBE_API_KEY` no `.env`. Se quiser, restrinja a chave à YouTube Data API v3.
+
+### IDs do servidor (Discord) e do canal (YouTube)
+
+**Discord — habilite o Modo de Desenvolvedor**:
+- Configurações do usuário → Avançado → ligue "Modo de desenvolvedor".
+- Agora clique-direito em qualquer servidor / canal / cargo → **Copiar ID**.
+- Pra `DISCORD_GUILD_ID`: clique-direito no nome do servidor → Copiar ID.
+- Pra `DISCORD_ANNOUNCE_CHANNEL_ID` / `DISCORD_LOG_CHANNEL_ID` / `DISCORD_WELCOME_CHANNEL_ID` / `DISCORD_MODS_CHANNEL_ID` / `DISCORD_REVIEW_CHANNEL_ID`: clique-direito no canal → Copiar ID.
+
+**YouTube — `YOUTUBE_CHANNEL_ID`**:
+- Painel de criador (`studio.youtube.com`) → Configurações → Canal → ID do canal. Começa com `UC...`.
+- Ou: na URL do seu canal `youtube.com/channel/UCxxxxxx`, é o segmento depois de `/channel/`.
+
+### Primeiro consentimento
+
+Na primeira vez que rodar algo que toca a API privada do YouTube (membros, vídeos não-listados):
+
+```sh
+uv run acelerado refresh-token
+```
+
+Vai abrir o navegador. Faça login com a conta do criador (a mesma cadastrada como "usuário de teste" na tela de consentimento OAuth). O token vai pra `token.pickle`. A partir daí, `acelerado run` funciona sem nova interação.
+
 ## Slash commands no Discord
 
 | Comando | Descrição |
@@ -214,6 +261,8 @@ token.pickle      # token OAuth em cache (gitignored)
 ```
 
 ## Como contribuir
+
+Veja [CONTRIBUTING.md](./CONTRIBUTING.md) pra um guia rápido (setup, padrões, workflow). Resumo:
 
 1. Faça um fork deste repositório.
 2. Clone o seu fork:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ uv sync
    | `DISCORD_WELCOME_CHANNEL_ID`    | (opcional) Canal pra mensagem de boas-vindas. Se `0`/vazio, tenta DM. |
    | `DISCORD_MODS_CHANNEL_ID`       | (opcional) Canal privado de mods. Recebe `/report`. |
    | `ACELERADO_LIVE_REMINDER_MINUTES`| (opcional) Quantos minutos antes do início de uma live agendada o bot avisa. Default `15`. |
+   | `DISCORD_REVIEW_CHANNEL_ID`     | (opcional) Canal privado pros rascunhos do resumo semanal aguardarem aprovação. |
+   | `ACELERADO_APOIADORES_WHITELIST`| (opcional) Usernames isentos do relatório de apoiadores stale. Default `eniaw`. |
 
 2. **Credenciais OAuth do Google** — copie o exemplo e substitua pelos valores da sua app:
 
@@ -68,6 +70,8 @@ uv sync
 | `/sync` | (admin) Força a sincronização de cargos `Registradores` na hora — útil quando alguém acabou de virar membro pago no YouTube e não quer esperar o tick. |
 | `/update` | (admin) Faz `git pull` + `uv sync` e reinicia o bot via wrapper (exit code 75). Veja "Restart automático" abaixo. |
 | `/report` | Reportar uma mensagem aos mods. Recebe link da mensagem (Copy Message Link) + motivo. Rate-limit de 3 reports / 10min por usuário. |
+| `/preview-summary` | (admin) Posta o rascunho do resumo semanal **agora** no canal de review (botões pra Aprovar / Editar / Descartar). |
+| `/preview-stale` | (admin) Posta a lista de apoiadores stale **agora** no canal de mods. |
 
 Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ uv sync
 | `/report` | Reportar uma mensagem aos mods. Recebe link da mensagem (Copy Message Link) + motivo. Rate-limit de 3 reports / 10min por usuário. |
 | `/preview-summary` | (admin) Posta o rascunho do resumo semanal **agora** no canal de review (botões pra Aprovar / Editar / Descartar). |
 | `/preview-stale` | (admin) Posta a lista de apoiadores stale **agora** no canal de mods. |
+| `/godbolt` | Gera link do [Compiler Explorer](https://godbolt.org) com seu código pré-carregado. Suporta C, C++, Rust, Zig, Go. |
 
 Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ uv sync
    | `ACELERADO_AUTO_THREAD`         | (opcional) Auto-cria thread no anúncio de vídeo, default `true` |
    | `DISCORD_WELCOME_CHANNEL_ID`    | (opcional) Canal pra mensagem de boas-vindas. Se `0`/vazio, tenta DM. |
    | `DISCORD_MODS_CHANNEL_ID`       | (opcional) Canal privado de mods. Recebe `/report`. |
+   | `ACELERADO_LIVE_REMINDER_MINUTES`| (opcional) Quantos minutos antes do início de uma live agendada o bot avisa. Default `15`. |
 
 2. **Credenciais OAuth do Google** — copie o exemplo e substitua pelos valores da sua app:
 

--- a/acelerado/bot.py
+++ b/acelerado/bot.py
@@ -1,14 +1,19 @@
+import datetime as _dt
 import logging
+from zoneinfo import ZoneInfo
 
 import discord
 from discord.ext import commands, tasks
 
-from acelerado import welcome
+from acelerado import review, welcome
 from acelerado.env import get_env
 from acelerado.slash import register_commands
 from acelerado.state import AceleradoState
 
 logger = logging.getLogger(__name__)
+
+# Mondays at 09:00 America/Sao_Paulo for the weekly drafts.
+_MON_9AM_SP = _dt.time(hour=9, minute=0, tzinfo=ZoneInfo("America/Sao_Paulo"))
 
 
 class AceleradoBot(commands.Bot):
@@ -23,6 +28,8 @@ class AceleradoBot(commands.Bot):
         # configured value before the first tick.
         self.event_loop_task.change_interval(seconds=get_env().ACELERADO_TICK_SECONDS)
         self.event_loop_task.start()
+        self.weekly_summary_task.start()
+        self.weekly_stale_task.start()
 
         # Register slash commands and sync them guild-scoped — propagates
         # instantly, unlike global sync (~1h). Bot is single-guild today.
@@ -94,6 +101,42 @@ class AceleradoBot(commands.Bot):
         await self.wait_until_ready()
         if self.state_handler is None:
             self.state_handler = AceleradoState(self)
+
+    # ------------------------------------------------------------------
+    # Weekly scheduled drafts (run Monday 9am SP)
+    # ------------------------------------------------------------------
+
+    @tasks.loop(time=[_MON_9AM_SP])
+    async def weekly_summary_task(self) -> None:
+        # discord.py's tasks.loop with `time=` fires daily at that time;
+        # gate to Mondays only.
+        if _dt.datetime.now(_MON_9AM_SP.tzinfo).weekday() != 0:
+            return
+        try:
+            await review.post_weekly_summary_draft(self)
+        except Exception as exc:
+            logger.exception("weekly_summary_task failed")
+            if self.state_handler is not None:
+                await self.state_handler.report_error("weekly_summary", exc)
+
+    @weekly_summary_task.before_loop
+    async def _before_weekly_summary(self) -> None:
+        await self.wait_until_ready()
+
+    @tasks.loop(time=[_MON_9AM_SP])
+    async def weekly_stale_task(self) -> None:
+        if _dt.datetime.now(_MON_9AM_SP.tzinfo).weekday() != 0:
+            return
+        try:
+            await review.post_stale_report(self)
+        except Exception as exc:
+            logger.exception("weekly_stale_task failed")
+            if self.state_handler is not None:
+                await self.state_handler.report_error("weekly_stale", exc)
+
+    @weekly_stale_task.before_loop
+    async def _before_weekly_stale(self) -> None:
+        await self.wait_until_ready()
 
     @event_loop_task.error
     async def _event_loop_error(self, exc: BaseException) -> None:

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -32,6 +32,15 @@ class EnvCfg(BaseSettings):
     # YouTube lives. The reminder fires once per video.
     ACELERADO_LIVE_REMINDER_MINUTES: int = 15
 
+    # Channel ID where weekly summary drafts await human approval before
+    # being posted publicly. Same channel works for stale-apoiadores reports
+    # if you don't want a separate one.
+    DISCORD_REVIEW_CHANNEL_ID: int = 0
+
+    # Whitelist of Discord usernames (NOT IDs — for human-edit convenience)
+    # that are exempt from the "stale apoiadores" report. Comma-separated.
+    ACELERADO_APOIADORES_WHITELIST: str = "eniaw"
+
 
 @lru_cache(maxsize=1)
 def get_env() -> EnvCfg:

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -28,6 +28,10 @@ class EnvCfg(BaseSettings):
     # with an "admin not configured" warning.
     DISCORD_MODS_CHANNEL_ID: int = 0
 
+    # Minutes-before-start to send a "live em N min" reminder for scheduled
+    # YouTube lives. The reminder fires once per video.
+    ACELERADO_LIVE_REMINDER_MINUTES: int = 15
+
 
 @lru_cache(maxsize=1)
 def get_env() -> EnvCfg:

--- a/acelerado/godbolt.py
+++ b/acelerado/godbolt.py
@@ -1,0 +1,74 @@
+"""Build Compiler Explorer (godbolt.org) ``clientstate`` URLs.
+
+The clientstate format encodes a JSON payload as URL-safe base64. We
+only emit single-session, single-compiler URLs — enough for
+``/godbolt`` to drop the user into a ready-to-tweak playground.
+
+Compiler IDs are Godbolt internals and may rotate over time. If a
+link stops loading the right compiler, update :data:`COMPILERS`.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+
+GODBOLT_BASE = "https://godbolt.org/clientstate/"
+
+
+@dataclass(frozen=True)
+class _Lang:
+    display: str  # what users see in the slash command picker
+    api_key: str  # Godbolt's "language" identifier
+    compiler: str  # Godbolt's compiler id
+
+
+# Edit here to add languages or update compilers.
+LANGUAGES: dict[str, _Lang] = {
+    "c": _Lang(display="C", api_key="c", compiler="cg132"),
+    "c++": _Lang(display="C++", api_key="c++", compiler="g132"),
+    "cpp": _Lang(display="C++ (alias cpp)", api_key="c++", compiler="g132"),
+    "rust": _Lang(display="Rust", api_key="rust", compiler="r1830"),
+    "zig": _Lang(display="Zig", api_key="zig", compiler="z0140"),
+    "go": _Lang(display="Go", api_key="go", compiler="gccgo132"),
+}
+
+
+def supported_keys() -> list[str]:
+    """Lowercase language keys accepted by :func:`build_clientstate_url`."""
+    # Stable order for consistent error messages.
+    return sorted(LANGUAGES)
+
+
+def build_clientstate_url(language: str, source: str) -> str:
+    """Return a ``godbolt.org/clientstate/<...>`` URL pre-loaded with the source.
+
+    Raises ``ValueError`` if the language isn't in :data:`LANGUAGES`.
+    """
+    lang = LANGUAGES.get(language.lower())
+    if lang is None:
+        raise ValueError(f"linguagem não suportada: {language!r}")
+
+    state = {
+        "sessions": [
+            {
+                "id": 1,
+                "language": lang.api_key,
+                "source": source,
+                "compilers": [{"id": lang.compiler, "options": ""}],
+            }
+        ]
+    }
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(state, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    return GODBOLT_BASE + encoded
+
+
+def decode_clientstate_url(url: str) -> dict:
+    """Inverse of :func:`build_clientstate_url`. Used by tests + debugging."""
+    if not url.startswith(GODBOLT_BASE):
+        raise ValueError(f"not a clientstate URL: {url}")
+    encoded = url[len(GODBOLT_BASE) :]
+    return json.loads(base64.urlsafe_b64decode(encoded).decode("utf-8"))

--- a/acelerado/godbolt.py
+++ b/acelerado/godbolt.py
@@ -24,7 +24,11 @@ class _Lang:
     compiler: str  # Godbolt's compiler id
 
 
-# Edit here to add languages or update compilers.
+# Edit here to add languages or update compilers. Compiler IDs come from
+# Godbolt — go to https://godbolt.org, pick the language + compiler,
+# inspect the URL: ``/api/compilers/<lang>`` lists the IDs. They rotate
+# as new versions ship; if a link stops opening the right compiler,
+# update the ``compiler`` field below.
 LANGUAGES: dict[str, _Lang] = {
     "c": _Lang(display="C", api_key="c", compiler="cg132"),
     "c++": _Lang(display="C++", api_key="c++", compiler="g132"),
@@ -32,6 +36,12 @@ LANGUAGES: dict[str, _Lang] = {
     "rust": _Lang(display="Rust", api_key="rust", compiler="r1830"),
     "zig": _Lang(display="Zig", api_key="zig", compiler="z0140"),
     "go": _Lang(display="Go", api_key="go", compiler="gccgo132"),
+    "python": _Lang(display="Python", api_key="python", compiler="python313"),
+    "javascript": _Lang(display="JavaScript", api_key="javascript", compiler="v8node2210"),
+    "js": _Lang(display="JavaScript (alias js)", api_key="javascript", compiler="v8node2210"),
+    "java": _Lang(display="Java", api_key="java", compiler="java2200"),
+    "haskell": _Lang(display="Haskell", api_key="haskell", compiler="ghc984"),
+    "odin": _Lang(display="Odin", api_key="odin", compiler="odintrunk"),
 }
 
 

--- a/acelerado/review.py
+++ b/acelerado/review.py
@@ -1,0 +1,296 @@
+"""Weekly summary + apoiadores-stale report — both posted to a private
+review channel for human approval before any public action.
+
+Design split:
+- **Builders** (``build_weekly_summary_text``, ``find_stale_apoiadores``)
+  are pure / easy to test offline. They take data and return strings or
+  member lists.
+- **Posters** (``post_weekly_summary_draft``, ``post_stale_report``)
+  are the async coroutines the bot's scheduled tasks call. They build,
+  post, and (for the weekly summary) attach a ``WeeklySummaryView`` for
+  human approval.
+
+The ``WeeklySummaryView`` is non-persistent (24h timeout); if the bot
+restarts mid-review, the buttons go dead — admins can re-trigger via
+``/preview-summary``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import discord
+from discord import app_commands, ui
+from discord.ext import commands
+
+from acelerado import youtube
+from acelerado.env import get_env
+
+logger = logging.getLogger(__name__)
+
+# How far back the weekly summary looks. 7 days, give or take.
+SUMMARY_WINDOW = timedelta(days=7)
+
+
+# ---------------------------------------------------------------------------
+# Builders (pure)
+# ---------------------------------------------------------------------------
+
+
+def build_weekly_summary_text(videos: list[dict], window: timedelta = SUMMARY_WINDOW) -> str:
+    """Render a Markdown summary of videos published in the last ``window``.
+
+    ``videos`` is a list of YouTube ``videos().list``-shaped dicts
+    (snippet + statistics expected). The function is pure — pass real
+    data or fixtures.
+    """
+    cutoff = datetime.now(UTC) - window
+
+    def _parse_published(video: dict) -> datetime | None:
+        raw = video.get("snippet", {}).get("publishedAt")
+        if not raw:
+            return None
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+
+    in_window: list[tuple[datetime, dict]] = []
+    for v in videos:
+        when = _parse_published(v)
+        if when is not None and when >= cutoff:
+            in_window.append((when, v))
+    in_window.sort(key=lambda pair: pair[0], reverse=True)
+
+    if not in_window:
+        return "## 📅 Resumo da semana\n_Nenhum vídeo novo publicado nos últimos 7 dias._\n"
+
+    lines = ["## 📅 Resumo da semana", f"**{len(in_window)} vídeos novos:**", ""]
+    for when, video in in_window:
+        title = video.get("snippet", {}).get("title", "<sem título>")
+        vid_id = video.get("id") or video.get("snippet", {}).get("resourceId", {}).get("videoId")
+        url = f"https://www.youtube.com/watch?v={vid_id}" if vid_id else ""
+        lines.append(f"- **{title}** ({when.strftime('%a %d/%m')}) — {url}")
+
+    # Top by views (only if statistics are present)
+    with_stats = [(v, int(v.get("statistics", {}).get("viewCount", 0))) for _, v in in_window]
+    with_stats = [(v, n) for v, n in with_stats if n > 0]
+    if with_stats:
+        with_stats.sort(key=lambda pair: pair[1], reverse=True)
+        top_video, top_views = with_stats[0]
+        top_title = top_video.get("snippet", {}).get("title", "<sem título>")
+        lines.append("")
+        lines.append(f"**🏆 Top da semana:** {top_title} ({top_views:,} views)")
+
+    return "\n".join(lines)
+
+
+def parse_username_whitelist(value: str) -> set[str]:
+    """Parse ``ACELERADO_APOIADORES_WHITELIST`` (comma-separated names) → set."""
+    return {item.strip() for item in value.split(",") if item.strip()}
+
+
+def find_stale_apoiadores(guild: discord.Guild) -> list[discord.Member]:
+    """Members holding ``Registradores`` but no role containing 'YouTube Member'.
+
+    Whitelisted usernames (env: ``ACELERADO_APOIADORES_WHITELIST``) are
+    excluded.
+    """
+    apoiadores = discord.utils.get(guild.roles, name="Registradores")
+    if apoiadores is None:
+        return []
+
+    whitelist = parse_username_whitelist(get_env().ACELERADO_APOIADORES_WHITELIST)
+
+    def _has_yt_role(member: discord.Member) -> bool:
+        return any("YouTube Member" in r.name for r in member.roles)
+
+    return [m for m in apoiadores.members if not _has_yt_role(m) and m.name not in whitelist]
+
+
+def format_stale_report(members: list[discord.Member]) -> str:
+    """Render the stale-apoiadores list for posting to mods."""
+    if not members:
+        return "✅ Nenhum apoiador stale essa semana."
+
+    lines = [
+        f"## 🩹 Apoiadores stale ({len(members)})",
+        "Membros com cargo `Registradores` mas sem cargo `YouTube Member`:",
+        "",
+    ]
+    for m in members:
+        lines.append(f"- {m.mention} (`{m.name}`, id `{m.id}`)")
+    lines.append("")
+    lines.append("_Decisão de remover o cargo permanece manual._")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Approval View
+# ---------------------------------------------------------------------------
+
+
+class _EditModal(ui.Modal, title="Editar resumo"):
+    new_text: ui.TextInput = ui.TextInput(
+        label="Texto",
+        style=discord.TextStyle.paragraph,
+        required=True,
+        max_length=3500,
+    )
+
+    def __init__(self, parent: WeeklySummaryView) -> None:
+        super().__init__()
+        self.parent = parent
+        self.new_text.default = parent.draft_text
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        self.parent.draft_text = self.new_text.value
+        # Update the original message to show the edited draft.
+        if interaction.message is not None:
+            await interaction.message.edit(content=self.new_text.value, view=self.parent)
+        await interaction.response.defer()
+
+
+class WeeklySummaryView(ui.View):
+    """Three-button view shown alongside the draft summary."""
+
+    def __init__(self, draft_text: str, announce_channel_id: int) -> None:
+        super().__init__(timeout=24 * 60 * 60)  # 24h
+        self.draft_text = draft_text
+        self.announce_channel_id = announce_channel_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        # Only mods (manage_messages) can act. discord.py auto-replies if False.
+        if isinstance(interaction.user, discord.Member):
+            if interaction.user.guild_permissions.manage_messages:
+                return True
+        await interaction.response.send_message(
+            "⚠️ Apenas mods podem decidir sobre essa proposta.",
+            ephemeral=True,
+        )
+        return False
+
+    @ui.button(label="✅ Aprovar e postar", style=discord.ButtonStyle.success)
+    async def approve(
+        self,
+        interaction: discord.Interaction,
+        _button: ui.Button,
+    ) -> None:
+        bot = cast(commands.Bot, interaction.client)
+        announce_channel = bot.get_channel(self.announce_channel_id)
+        if not isinstance(announce_channel, discord.abc.Messageable):
+            await interaction.response.send_message(
+                "⚠️ Canal de anúncios não acessível.", ephemeral=True
+            )
+            return
+        await announce_channel.send(self.draft_text)
+        if interaction.message is not None:
+            await interaction.message.edit(content=f"✅ APROVADO\n\n{self.draft_text}", view=None)
+        await interaction.response.send_message("Postado!", ephemeral=True)
+        self.stop()
+
+    @ui.button(label="✏️ Editar", style=discord.ButtonStyle.primary)
+    async def edit(
+        self,
+        interaction: discord.Interaction,
+        _button: ui.Button,
+    ) -> None:
+        await interaction.response.send_modal(_EditModal(self))
+
+    @ui.button(label="🚫 Descartar", style=discord.ButtonStyle.danger)
+    async def discard(
+        self,
+        interaction: discord.Interaction,
+        _button: ui.Button,
+    ) -> None:
+        if interaction.message is not None:
+            await interaction.message.edit(content=f"🚫 DESCARTADO\n\n{self.draft_text}", view=None)
+        await interaction.response.send_message("Descartado.", ephemeral=True)
+        self.stop()
+
+
+# ---------------------------------------------------------------------------
+# Async posters (called from scheduled tasks + admin slashes)
+# ---------------------------------------------------------------------------
+
+
+async def post_weekly_summary_draft(bot: commands.Bot) -> str:
+    """Post the weekly summary draft to ``DISCORD_REVIEW_CHANNEL_ID``.
+
+    Returns a short status string for ephemeral feedback.
+    """
+    cfg = get_env()
+    if not cfg.DISCORD_REVIEW_CHANNEL_ID:
+        return "⚠️ DISCORD_REVIEW_CHANNEL_ID não configurado."
+    review_channel = bot.get_channel(cfg.DISCORD_REVIEW_CHANNEL_ID)
+    if not isinstance(review_channel, discord.abc.Messageable):
+        return "⚠️ Canal de review não acessível."
+
+    items = youtube.get_last_videos(max_videos=20)
+    # Convert playlistItem-shaped dicts into video-shaped (we need the videoId
+    # to fetch the full info incl. statistics).
+    full_videos: list[dict] = []
+    for item in items:
+        vid = youtube.get_video_id(item)
+        try:
+            full_videos.append(youtube.get_video_info(vid))
+        except Exception as exc:
+            logger.warning(f"Could not fetch video {vid} for summary: {exc}")
+
+    draft = build_weekly_summary_text(full_videos)
+    view = WeeklySummaryView(draft, cfg.DISCORD_ANNOUNCE_CHANNEL_ID)
+    await review_channel.send(content=draft, view=view)
+    return "✅ Rascunho postado no canal de review."
+
+
+async def post_stale_report(bot: commands.Bot) -> str:
+    """Post the stale-apoiadores list to ``DISCORD_MODS_CHANNEL_ID``."""
+    cfg = get_env()
+    target_id = cfg.DISCORD_MODS_CHANNEL_ID or cfg.DISCORD_REVIEW_CHANNEL_ID
+    if not target_id:
+        return "⚠️ Sem canal de mods/review configurado."
+
+    target = bot.get_channel(target_id)
+    if not isinstance(target, discord.abc.Messageable):
+        return "⚠️ Canal de mods não acessível."
+
+    guild = bot.get_guild(cfg.DISCORD_GUILD_ID)
+    if guild is None:
+        return "⚠️ Guild não encontrada no cache."
+
+    stale = find_stale_apoiadores(guild)
+    await target.send(format_stale_report(stale))
+    return f"✅ Relatório postado: {len(stale)} stale."
+
+
+# ---------------------------------------------------------------------------
+# Admin slash commands — manual trigger
+# ---------------------------------------------------------------------------
+
+
+@app_commands.command(
+    name="preview-summary",
+    description="(admin) Posta o rascunho do resumo semanal no canal de review",
+)
+@app_commands.default_permissions(administrator=True)
+async def cmd_preview_summary(interaction: discord.Interaction) -> None:
+    bot = cast(commands.Bot, interaction.client)
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    msg = await post_weekly_summary_draft(bot)
+    await interaction.followup.send(msg, ephemeral=True)
+
+
+@app_commands.command(
+    name="preview-stale",
+    description="(admin) Posta o relatório de apoiadores stale agora",
+)
+@app_commands.default_permissions(administrator=True)
+async def cmd_preview_stale(interaction: discord.Interaction) -> None:
+    bot = cast(commands.Bot, interaction.client)
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    msg = await post_stale_report(bot)
+    await interaction.followup.send(msg, ephemeral=True)

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -143,7 +143,7 @@ _MESSAGE_LINK_RE = re.compile(r"https?://(?:\w+\.)?discord\.com/channels/(\d+)/(
     description="Gera link do Compiler Explorer com seu código",
 )
 @app_commands.describe(
-    language="Linguagem do código (c, c++, rust, zig, go)",
+    language="Linguagem do código",
     code="Código (até ~3000 chars)",
 )
 @app_commands.choices(
@@ -153,6 +153,11 @@ _MESSAGE_LINK_RE = re.compile(r"https?://(?:\w+\.)?discord\.com/channels/(\d+)/(
         app_commands.Choice(name="Rust", value="rust"),
         app_commands.Choice(name="Zig", value="zig"),
         app_commands.Choice(name="Go", value="go"),
+        app_commands.Choice(name="Python", value="python"),
+        app_commands.Choice(name="JavaScript", value="javascript"),
+        app_commands.Choice(name="Java", value="java"),
+        app_commands.Choice(name="Haskell", value="haskell"),
+        app_commands.Choice(name="Odin", value="odin"),
     ]
 )
 async def cmd_godbolt(

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -201,7 +201,11 @@ def register_commands(
     Pass ``guild=`` to scope commands to a single guild (instant sync,
     great for dev). Pass ``None`` to register globally (~1h propagation).
     """
+    from acelerado.review import cmd_preview_stale, cmd_preview_summary
+
     tree.add_command(cmd_links, guild=guild)
     tree.add_command(cmd_sync, guild=guild)
     tree.add_command(cmd_update, guild=guild)
     tree.add_command(cmd_report, guild=guild)
+    tree.add_command(cmd_preview_summary, guild=guild)
+    tree.add_command(cmd_preview_stale, guild=guild)

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -138,6 +138,50 @@ async def _delayed_exit(code: int, delay_seconds: float = 3.0) -> None:
 _MESSAGE_LINK_RE = re.compile(r"https?://(?:\w+\.)?discord\.com/channels/(\d+)/(\d+)/(\d+)")
 
 
+@app_commands.command(
+    name="godbolt",
+    description="Gera link do Compiler Explorer com seu código",
+)
+@app_commands.describe(
+    language="Linguagem do código (c, c++, rust, zig, go)",
+    code="Código (até ~3000 chars)",
+)
+@app_commands.choices(
+    language=[
+        app_commands.Choice(name="C", value="c"),
+        app_commands.Choice(name="C++", value="c++"),
+        app_commands.Choice(name="Rust", value="rust"),
+        app_commands.Choice(name="Zig", value="zig"),
+        app_commands.Choice(name="Go", value="go"),
+    ]
+)
+async def cmd_godbolt(
+    interaction: discord.Interaction,
+    language: app_commands.Choice[str],
+    code: str,
+) -> None:
+    from acelerado import godbolt
+
+    try:
+        url = godbolt.build_clientstate_url(language.value, code)
+    except ValueError as exc:
+        await interaction.response.send_message(
+            f"⚠️ {exc}. Suportadas: {', '.join(godbolt.supported_keys())}",
+            ephemeral=True,
+        )
+        return
+
+    embed = discord.Embed(
+        title=f"🔗 Compiler Explorer — {language.name}",
+        description=f"[Abrir no godbolt.org]({url})",
+        color=discord.Color.dark_orange(),
+    )
+    embed.add_field(name="Snippet", value=f"```{language.value}\n{code[:500]}\n```", inline=False)
+    if len(code) > 500:
+        embed.set_footer(text=f"(snippet truncado — {len(code)} chars no link)")
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
 @app_commands.command(name="report", description="Reportar uma mensagem aos mods")
 @app_commands.describe(
     message_link="Link da mensagem (clique-direito → Copy Message Link)",
@@ -209,3 +253,4 @@ def register_commands(
     tree.add_command(cmd_report, guild=guild)
     tree.add_command(cmd_preview_summary, guild=guild)
     tree.add_command(cmd_preview_stale, guild=guild)
+    tree.add_command(cmd_godbolt, guild=guild)

--- a/acelerado/state.py
+++ b/acelerado/state.py
@@ -16,6 +16,7 @@ ROLE_NAME_APOIADORES = "Registradores"
 ROLE_NAME_YT_MEMBER_SUBSTRING = "YouTube Member"
 FILENAME_PUBLISHED = Path("published.txt")
 LAST_TICK_PATH = Path("last_tick.txt")
+LIVE_REMINDERS_PATH = Path("live_reminders.txt")
 
 # How often we're willing to post a "something blew up" report to Discord.
 # Local logs are always emitted; this only throttles the remote notification
@@ -108,6 +109,11 @@ class AceleradoState:
 
     def should_announce_video(self, video: dict) -> bool:
         if youtube.is_non_listed(video):
+            return False
+        # Scheduled-but-not-yet-live: handled by _check_upcoming_lives
+        # (reminder), not here. Avoid announcing "Estamos em live!" before
+        # the live actually starts.
+        if youtube.is_livestream(video) and not youtube.is_live_now(video):
             return False
         if not youtube.is_processed(video) and not youtube.is_livestream(video):
             return False
@@ -272,6 +278,57 @@ class AceleradoState:
     # Tick
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Upcoming livestream reminders
+    # ------------------------------------------------------------------
+
+    @property
+    def live_reminders_sent(self) -> set[str]:
+        """Already-reminded video IDs from ``live_reminders.txt``."""
+        if not LIVE_REMINDERS_PATH.exists():
+            return set()
+        return {ln.strip() for ln in LIVE_REMINDERS_PATH.read_text().splitlines() if ln.strip()}
+
+    def _record_live_reminder(self, video_id: str) -> None:
+        if video_id in self.live_reminders_sent:
+            return
+        if not LIVE_REMINDERS_PATH.exists():
+            LIVE_REMINDERS_PATH.write_text("")
+        current = LIVE_REMINDERS_PATH.read_text()
+        prefix = "" if not current or current.endswith("\n") else "\n"
+        with LIVE_REMINDERS_PATH.open("a") as f:
+            f.write(f"{prefix}{video_id}\n")
+
+    async def _check_upcoming_lives(self) -> None:
+        """Send a "live em N min" reminder for any scheduled live within window."""
+        now = datetime.now(UTC)
+        window = timedelta(minutes=get_env().ACELERADO_LIVE_REMINDER_MINUTES)
+        sent = self.live_reminders_sent
+
+        for vid in youtube.get_upcoming_livestream_ids():
+            if vid in sent:
+                continue
+            video = youtube.get_video_info(vid)
+            scheduled = youtube.get_scheduled_start_time(video)
+            if scheduled is None:
+                continue
+            time_until = scheduled - now
+            if time_until < timedelta(0) or time_until > window:
+                continue
+
+            title = youtube.get_video_title(video)
+            url = youtube.get_video_url(vid)
+            minutes = max(1, int(time_until.total_seconds() / 60))
+            msg = f"@everyone 🔔 Live em ~{minutes} min: **{title}**\n{url}"
+
+            channel = self.channel_announce
+            if channel is None:
+                logger.error("Announce channel disappeared; can't send live reminder")
+                return
+            await channel.send(msg)
+            self._record_live_reminder(vid)
+            logger.info(f"Posted live reminder for {vid} ({title})")
+
     async def _pub_new_videos(self) -> None:
         """Inner video-announcement step — pulled out so event_loop reads linearly."""
         for video_id in self.check_videos_to_pub():
@@ -292,6 +349,7 @@ class AceleradoState:
         steps = [
             ("apoiadores", self.check_members_apoiadores),
             ("expiration", self.check_expiration),
+            ("upcoming_lives", self._check_upcoming_lives),
             ("videos", self._pub_new_videos),
         ]
         for name, step in steps:

--- a/acelerado/updater.py
+++ b/acelerado/updater.py
@@ -59,9 +59,7 @@ def _run(cmd: list[str], cwd: Path, timeout: float = _DEFAULT_TIMEOUT) -> tuple[
     ``timeout(1)``) so callers can tell it apart from a normal non-zero exit.
     """
     try:
-        proc = subprocess.run(
-            cmd, capture_output=True, text=True, cwd=str(cwd), timeout=timeout
-        )
+        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(cwd), timeout=timeout)
     except subprocess.TimeoutExpired:
         return 124, "", f"timed out after {timeout:.0f}s"
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()

--- a/acelerado/youtube.py
+++ b/acelerado/youtube.py
@@ -126,6 +126,49 @@ def is_livestream(video: dict) -> bool:
     return "liveStreamingDetails" in video
 
 
+def is_live_now(video: dict) -> bool:
+    """True only when the live has actually started (and not yet ended).
+
+    A merely *scheduled* live also has ``liveStreamingDetails`` but no
+    ``actualStartTime``. Use this to distinguish "live right now" from
+    "live coming soon".
+    """
+    details = video.get("liveStreamingDetails", {})
+    return "actualStartTime" in details and "actualEndTime" not in details
+
+
+def get_scheduled_start_time(video: dict) -> datetime | None:
+    """Return ``scheduledStartTime`` as aware UTC datetime, or None."""
+    raw = video.get("liveStreamingDetails", {}).get("scheduledStartTime")
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        logger.warning(f"Invalid scheduledStartTime format: {raw!r}")
+        return None
+
+
+def get_upcoming_livestream_ids(max_results: int = 5) -> list[str]:
+    """Return video IDs for scheduled (not-yet-started) lives on the configured channel."""
+    response = (
+        _youtube()
+        .search()
+        .list(
+            part="snippet",
+            channelId=get_env().YOUTUBE_CHANNEL_ID,
+            type="video",
+            eventType="upcoming",
+            maxResults=max_results,
+        )
+        .execute()
+    )
+    items = response.get("items", [])
+    return [item["id"]["videoId"] for item in items if "videoId" in item.get("id", {})]
+
+
 def is_non_listed(video: dict) -> bool:
     return video["status"]["privacyStatus"] != "public"
 

--- a/tests/test_godbolt.py
+++ b/tests/test_godbolt.py
@@ -1,0 +1,51 @@
+"""Tests for ``acelerado.godbolt`` URL builder."""
+
+from __future__ import annotations
+
+import pytest
+
+from acelerado import godbolt
+
+
+def test_supported_keys_includes_known_languages():
+    keys = godbolt.supported_keys()
+    assert {"c", "c++", "rust", "zig", "go"} <= set(keys)
+
+
+@pytest.mark.parametrize("lang", ["c", "c++", "rust", "zig", "go"])
+def test_build_url_returns_clientstate(lang):
+    url = godbolt.build_clientstate_url(lang, "hello")
+    assert url.startswith(godbolt.GODBOLT_BASE)
+
+
+def test_build_url_round_trip_preserves_source():
+    code = "int main() { return 42; }"
+    url = godbolt.build_clientstate_url("c", code)
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["source"] == code
+    assert state["sessions"][0]["language"] == "c"
+    assert state["sessions"][0]["compilers"][0]["id"] == godbolt.LANGUAGES["c"].compiler
+
+
+def test_build_url_handles_unicode_source():
+    code = 'fn main() { println!("olá, açaí 🥭"); }'
+    url = godbolt.build_clientstate_url("rust", code)
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["source"] == code
+
+
+def test_build_url_unknown_language_raises():
+    with pytest.raises(ValueError, match="não suportada"):
+        godbolt.build_clientstate_url("brainfuck", "+++.")
+
+
+def test_alias_cpp_maps_to_cpp():
+    url = godbolt.build_clientstate_url("cpp", "int x;")
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["language"] == "c++"
+
+
+def test_language_case_insensitive():
+    a = godbolt.build_clientstate_url("RUST", "x")
+    b = godbolt.build_clientstate_url("rust", "x")
+    assert a == b

--- a/tests/test_godbolt.py
+++ b/tests/test_godbolt.py
@@ -9,10 +9,38 @@ from acelerado import godbolt
 
 def test_supported_keys_includes_known_languages():
     keys = godbolt.supported_keys()
-    assert {"c", "c++", "rust", "zig", "go"} <= set(keys)
+    expected = {
+        "c",
+        "c++",
+        "rust",
+        "zig",
+        "go",
+        "python",
+        "javascript",
+        "js",
+        "java",
+        "haskell",
+        "odin",
+    }
+    assert expected <= set(keys)
 
 
-@pytest.mark.parametrize("lang", ["c", "c++", "rust", "zig", "go"])
+@pytest.mark.parametrize(
+    "lang",
+    [
+        "c",
+        "c++",
+        "rust",
+        "zig",
+        "go",
+        "python",
+        "javascript",
+        "js",
+        "java",
+        "haskell",
+        "odin",
+    ],
+)
 def test_build_url_returns_clientstate(lang):
     url = godbolt.build_clientstate_url(lang, "hello")
     assert url.startswith(godbolt.GODBOLT_BASE)
@@ -43,6 +71,12 @@ def test_alias_cpp_maps_to_cpp():
     url = godbolt.build_clientstate_url("cpp", "int x;")
     state = godbolt.decode_clientstate_url(url)
     assert state["sessions"][0]["language"] == "c++"
+
+
+def test_alias_js_maps_to_javascript():
+    url = godbolt.build_clientstate_url("js", "console.log(1)")
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["language"] == "javascript"
 
 
 def test_language_case_insensitive():

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,215 @@
+"""Tests for ``acelerado.review`` — pure builders, lightly the posters."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from acelerado import review
+
+# ---------------------------------------------------------------------------
+# Weekly summary builder
+# ---------------------------------------------------------------------------
+
+
+def _video(video_id: str, title: str, days_ago: float, views: int = 0) -> dict:
+    when = datetime.now(UTC) - timedelta(days=days_ago)
+    iso = when.isoformat().replace("+00:00", "Z")
+    return {
+        "id": video_id,
+        "snippet": {"title": title, "publishedAt": iso},
+        "statistics": {"viewCount": str(views)},
+    }
+
+
+def test_summary_empty_when_no_recent_videos():
+    text = review.build_weekly_summary_text([_video("old", "Antigo", days_ago=20)])
+    assert "Nenhum vídeo novo" in text
+
+
+def test_summary_lists_videos_in_window():
+    videos = [
+        _video("a", "Video A", days_ago=2),
+        _video("b", "Video B", days_ago=5),
+        _video("c", "Velho", days_ago=15),  # outside window
+    ]
+    text = review.build_weekly_summary_text(videos)
+    assert "Video A" in text
+    assert "Video B" in text
+    assert "Velho" not in text
+    # Count line
+    assert "**2 vídeos novos:**" in text
+
+
+def test_summary_includes_top_when_stats_present():
+    videos = [
+        _video("a", "Top vídeo", days_ago=1, views=10000),
+        _video("b", "Médio", days_ago=2, views=500),
+        _video("c", "Baixo", days_ago=3, views=10),
+    ]
+    text = review.build_weekly_summary_text(videos)
+    assert "🏆 Top da semana" in text
+    assert "Top vídeo" in text
+
+
+def test_summary_omits_top_when_no_stats():
+    # No statistics -> no top section
+    videos = [{"id": "x", "snippet": {"title": "x", "publishedAt": "2026-04-25T00:00:00Z"}}]
+    text = review.build_weekly_summary_text(videos)
+    assert "🏆 Top" not in text
+
+
+# ---------------------------------------------------------------------------
+# Stale apoiadores builder
+# ---------------------------------------------------------------------------
+
+
+def _make_role(name: str) -> MagicMock:
+    r = MagicMock(spec=discord.Role)
+    r.name = name
+    r.members = []
+    return r
+
+
+def _make_member(name: str, member_id: int, roles: list) -> MagicMock:
+    m = MagicMock(spec=discord.Member)
+    m.name = name
+    m.id = member_id
+    m.mention = f"<@{member_id}>"
+    m.roles = roles
+    return m
+
+
+def test_find_stale_returns_empty_when_role_missing():
+    guild = MagicMock(spec=discord.Guild)
+    guild.roles = [_make_role("@everyone")]
+    assert review.find_stale_apoiadores(guild) == []
+
+
+def test_find_stale_lists_members_without_yt_role(monkeypatch):
+    monkeypatch.setenv("ACELERADO_APOIADORES_WHITELIST", "")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    apoiadores = _make_role("Registradores")
+    yt_t1 = _make_role("YouTube Member (Nível 1)")
+
+    alice = _make_member("alice", 1, [apoiadores])  # stale
+    bob = _make_member("bob", 2, [apoiadores, yt_t1])  # OK
+    apoiadores.members = [alice, bob]
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.roles = [apoiadores, yt_t1]
+
+    stale = review.find_stale_apoiadores(guild)
+    assert [m.id for m in stale] == [1]
+
+
+def test_find_stale_respects_whitelist(monkeypatch):
+    monkeypatch.setenv("ACELERADO_APOIADORES_WHITELIST", "alice,carol")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    apoiadores = _make_role("Registradores")
+    alice = _make_member("alice", 1, [apoiadores])
+    bob = _make_member("bob", 2, [apoiadores])
+    apoiadores.members = [alice, bob]
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.roles = [apoiadores]
+
+    stale = review.find_stale_apoiadores(guild)
+    # alice whitelisted, bob remains
+    assert [m.name for m in stale] == ["bob"]
+
+
+def test_format_stale_report_empty():
+    out = review.format_stale_report([])
+    assert "Nenhum apoiador stale" in out
+
+
+def test_format_stale_report_with_members():
+    apoiadores = _make_role("Registradores")
+    members = [_make_member("alice", 1, [apoiadores]), _make_member("bob", 2, [apoiadores])]
+    out = review.format_stale_report(members)
+    assert "<@1>" in out
+    assert "<@2>" in out
+    assert "alice" in out
+    assert "bob" in out
+
+
+def test_parse_username_whitelist():
+    assert review.parse_username_whitelist("") == set()
+    assert review.parse_username_whitelist("a, b ,c") == {"a", "b", "c"}
+
+
+# ---------------------------------------------------------------------------
+# Posters — high-level: missing config returns warning
+# ---------------------------------------------------------------------------
+
+
+async def test_post_weekly_summary_no_review_channel_returns_warning(monkeypatch):
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "0")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = MagicMock()
+    msg = await review.post_weekly_summary_draft(bot)
+    assert "não configurado" in msg.lower()
+
+
+async def test_post_stale_report_no_target_returns_warning(monkeypatch):
+    monkeypatch.setenv("DISCORD_MODS_CHANNEL_ID", "0")
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "0")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    bot = MagicMock()
+    msg = await review.post_stale_report(bot)
+    assert "configurado" in msg.lower()
+
+
+async def test_post_stale_report_posts_message(monkeypatch):
+    monkeypatch.setenv("DISCORD_MODS_CHANNEL_ID", "555")
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+    apoiadores = _make_role("Registradores")
+    apoiadores.members = []
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.roles = [apoiadores]
+
+    target = MagicMock(spec=discord.TextChannel)
+    target.send = AsyncMock()
+
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=target)
+    bot.get_guild = MagicMock(return_value=guild)
+
+    msg = await review.post_stale_report(bot)
+    target.send.assert_awaited_once()
+    assert "Nenhum apoiador stale" in target.send.await_args.args[0]
+    assert "✅" in msg
+
+
+@pytest.mark.parametrize("cmd_name", ["preview-summary", "preview-stale"])
+def test_admin_preview_commands_are_registered(cmd_name):
+    """Sanity: register_commands wires both preview slashes guild-scoped."""
+    from acelerado.slash import register_commands
+
+    intents = discord.Intents.default()
+    client = discord.Client(intents=intents)
+    tree = discord.app_commands.CommandTree(client)
+    guild = discord.Object(id=42)
+    register_commands(tree, guild=guild)
+
+    assert tree.get_command(cmd_name, guild=guild) is not None

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -239,6 +239,33 @@ async def test_register_report_command():
     assert cmd.name == "report"
 
 
+def test_register_godbolt_command():
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    cmd = tree.get_command("godbolt", guild=guild)
+    assert cmd is not None
+    assert cmd.name == "godbolt"
+
+
+async def test_godbolt_command_returns_url_in_embed():
+    from discord import app_commands
+
+    from acelerado.slash import cmd_godbolt
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    choice = app_commands.Choice(name="C", value="c")
+    await cmd_godbolt.callback(interaction, language=choice, code="int main(){return 0;}")
+
+    interaction.response.send_message.assert_awaited_once()
+    embed = interaction.response.send_message.await_args.kwargs.get("embed")
+    assert embed is not None
+    assert "godbolt.org/clientstate/" in (embed.description or "")
+
+
 async def test_report_invalid_link_responds_with_warning():
     from acelerado.slash import cmd_report
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -393,6 +393,90 @@ async def test_report_error_increments_metric(built_state, chdir_tmp):
     assert any(e.context == "ctx_a" for e in loaded.errors)
 
 
+# ---------------------------------------------------------------------------
+# Upcoming livestream reminders
+# ---------------------------------------------------------------------------
+
+
+def _scheduled_video(make_video_fn, video_id: str, minutes_from_now: int):
+    """Build a video dict for a scheduled (not-yet-started) live."""
+    when = datetime.now(UTC) + timedelta(minutes=minutes_from_now)
+    video = make_video_fn(video_id=video_id, livestream=True)
+    video["liveStreamingDetails"] = {
+        "scheduledStartTime": when.isoformat().replace("+00:00", "Z"),
+    }
+    return video
+
+
+async def test_check_upcoming_lives_reminds_within_window(
+    built_state, fake_guild, monkeypatch, make_video_fn
+):
+    video = _scheduled_video(make_video_fn, "live1", minutes_from_now=10)
+    monkeypatch.setattr(yt_mod, "get_upcoming_livestream_ids", lambda max_results=5: ["live1"])
+    monkeypatch.setattr(yt_mod, "get_video_info", lambda vid: video)
+
+    await built_state._check_upcoming_lives()
+
+    fake_guild._announce.send.assert_awaited_once()
+    msg = fake_guild._announce.send.await_args.args[0]
+    assert "🔔" in msg
+    assert "live1" in msg or "watch?v=live1" in msg
+
+
+async def test_check_upcoming_lives_skips_outside_window(
+    built_state, fake_guild, monkeypatch, make_video_fn
+):
+    # 90 minutes away — outside default 15min window
+    video = _scheduled_video(make_video_fn, "live1", minutes_from_now=90)
+    monkeypatch.setattr(yt_mod, "get_upcoming_livestream_ids", lambda max_results=5: ["live1"])
+    monkeypatch.setattr(yt_mod, "get_video_info", lambda vid: video)
+
+    await built_state._check_upcoming_lives()
+    fake_guild._announce.send.assert_not_awaited()
+
+
+async def test_check_upcoming_lives_skips_past_start_time(
+    built_state, fake_guild, monkeypatch, make_video_fn
+):
+    video = _scheduled_video(make_video_fn, "live1", minutes_from_now=-5)
+    monkeypatch.setattr(yt_mod, "get_upcoming_livestream_ids", lambda max_results=5: ["live1"])
+    monkeypatch.setattr(yt_mod, "get_video_info", lambda vid: video)
+
+    await built_state._check_upcoming_lives()
+    fake_guild._announce.send.assert_not_awaited()
+
+
+async def test_check_upcoming_lives_dedups_across_ticks(
+    built_state, fake_guild, monkeypatch, make_video_fn, chdir_tmp
+):
+    video = _scheduled_video(make_video_fn, "live1", minutes_from_now=5)
+    monkeypatch.setattr(yt_mod, "get_upcoming_livestream_ids", lambda max_results=5: ["live1"])
+    monkeypatch.setattr(yt_mod, "get_video_info", lambda vid: video)
+
+    await built_state._check_upcoming_lives()
+    await built_state._check_upcoming_lives()  # second tick — should NOT remind again
+
+    assert fake_guild._announce.send.await_count == 1
+    # live_reminders.txt persists the dedup
+    from acelerado import state as state_mod
+
+    assert "live1" in state_mod.LIVE_REMINDERS_PATH.read_text()
+
+
+def test_should_announce_skips_scheduled_but_not_started(built_state, make_video_fn):
+    video = make_video_fn(livestream=True)
+    video["liveStreamingDetails"] = {"scheduledStartTime": "2099-01-01T00:00:00Z"}
+    assert built_state.should_announce_video(video) is False
+
+
+def test_should_announce_passes_for_started_live(built_state, make_video_fn):
+    video = make_video_fn(livestream=True)
+    video["liveStreamingDetails"] = {
+        "actualStartTime": "2026-04-25T19:00:00Z",
+    }
+    assert built_state.should_announce_video(video) is True
+
+
 async def test_event_loop_isolates_step_errors(built_state, monkeypatch):
     async def raising():
         raise RuntimeError("boom")

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -161,6 +161,63 @@ def test_time_to_expire_is_positive_for_future_token(token_future):
     assert 29 * 86400 < seconds < 31 * 86400
 
 
+# ---------------------------------------------------------------------------
+# Upcoming livestreams
+# ---------------------------------------------------------------------------
+
+
+def test_is_live_now_distinguishes_scheduled_from_actual(make_video_fn):
+    scheduled = make_video_fn(livestream=True)
+    # default fixture sets actualStartTime; remove to simulate "scheduled"
+    scheduled["liveStreamingDetails"] = {"scheduledStartTime": "2026-04-25T19:00:00Z"}
+    assert youtube.is_livestream(scheduled) is True
+    assert youtube.is_live_now(scheduled) is False
+
+    live = make_video_fn(livestream=True)
+    live["liveStreamingDetails"] = {
+        "actualStartTime": "2026-04-25T19:00:00Z",
+        "scheduledStartTime": "2026-04-25T19:00:00Z",
+    }
+    assert youtube.is_live_now(live) is True
+
+
+def test_is_live_now_false_when_ended(make_video_fn):
+    video = make_video_fn(livestream=True)
+    video["liveStreamingDetails"] = {
+        "actualStartTime": "2026-04-25T19:00:00Z",
+        "actualEndTime": "2026-04-25T20:00:00Z",
+    }
+    assert youtube.is_live_now(video) is False
+
+
+def test_get_scheduled_start_time_parses_z_suffix(make_video_fn):
+    video = make_video_fn(livestream=True)
+    video["liveStreamingDetails"] = {"scheduledStartTime": "2026-04-25T19:00:00Z"}
+    parsed = youtube.get_scheduled_start_time(video)
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+    assert parsed.year == 2026 and parsed.month == 4 and parsed.day == 25
+
+
+def test_get_scheduled_start_time_returns_none_when_missing(make_video_fn):
+    assert youtube.get_scheduled_start_time(make_video_fn()) is None
+
+
+def test_get_upcoming_livestream_ids(monkeypatch):
+    client = _fake_youtube_client()
+    client.search.return_value.list.return_value.execute.return_value = {
+        "items": [
+            {"id": {"videoId": "live1", "kind": "youtube#video"}},
+            {"id": {"videoId": "live2", "kind": "youtube#video"}},
+            {"id": {"kind": "youtube#channel"}},  # malformed entry — skipped
+        ]
+    }
+    monkeypatch.setattr(youtube, "_youtube", lambda: client)
+
+    ids = youtube.get_upcoming_livestream_ids()
+    assert ids == ["live1", "live2"]
+
+
 def test_time_to_expire_negative_for_past_token(write_token):
     write_token(datetime.now(UTC) - timedelta(days=1))
     seconds = youtube.get_token_time_to_expire()


### PR DESCRIPTION
**Stacked on #25.** Cumulative merge order: #20 → #21 → #22 → #23 → #24 → #25 → this.

Implementa #6: aviso "🔔 Live em N min" antes do início de lives agendadas, com dedup persistente.

## Bug pré-existente corrigido
Antes desta PR, lives **agendadas** (com \`scheduledStartTime\` mas sem \`actualStartTime\`) eram detectadas por \`is_livestream\` e anunciadas como **"Estamos em live!"** mesmo antes de começarem. Agora \`should_announce_video\` requer \`actualStartTime\` (via novo helper \`is_live_now\`) — o reminder cobre o pré-anúncio.

## Helpers novos em \`youtube.py\`
- \`is_live_now(video)\` — \`actualStartTime\` set + \`actualEndTime\` não set.
- \`get_scheduled_start_time(video)\` — parse aware UTC.
- \`get_upcoming_livestream_ids(max_results=5)\` — \`search().list(eventType=upcoming)\`.

## State
Novo passo \`_check_upcoming_lives\` em \`event_loop\` (entre \`expiration\` e \`videos\`):
1. Lista IDs upcoming.
2. Filtra já-reminded (\`live_reminders.txt\`, mesmo padrão de \`published.txt\`).
3. Pula se \`scheduledStartTime\` já passou ou está além de \`ACELERADO_LIVE_REMINDER_MINUTES\` (default 15).
4. Posta \`@everyone 🔔 Live em ~N min: **título**\n<url>\` e registra.

## Test plan
- [x] \`pytest\` 160/160 (149 → 160).
- [x] \`ruff\`, \`mypy\` clean.
- [ ] Smoke produção: agendar uma live no canal, ajustar \`ACELERADO_LIVE_REMINDER_MINUTES\` se necessário, verificar que o aviso cai uma vez no canal de anúncios.
- [ ] Smoke: confirmar que quando a live de fato começa, a mensagem \`Estamos em live!\` aparece (porque \`actualStartTime\` é setado).

Closes #6