### PR TITLE
feat: /godbolt slash for Compiler Explorer links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Como contribuir
+
+Obrigado por considerar contribuir com o Acelerado! Esse guia é o caminho rápido.
+
+## Pré-requisitos
+
+- **Python 3.11+**
+- [`uv`](https://docs.astral.sh/uv/) — `pip install -U uv`
+- Conta no [Discord Developer Portal](https://discord.com/developers/applications) para criar um bot de testes.
+- (Opcional) Credenciais OAuth do Google + chave da YouTube Data API v3 — só se for mexer com a parte de YouTube.
+
+## Setup local
+
+```sh
+git clone https://github.com/seu-usuario/discord.git
+cd discord
+uv sync                                 # instala deps + dev deps
+cp .example.env .env                    # depois edite com seus valores
+cp credentials.example.json credentials.json   # depois cole o JSON da app Google
+```
+
+Veja a seção **"Como obter credenciais"** no [`README.md`](./README.md) pra um passo-a-passo de Discord + Google Cloud.
+
+## Workflow de contribuição
+
+1. **Branch**: `feat/<descrição-curta>`, `fix/<bug>`, `docs/<o-que>`.
+2. **Antes de commitar**, rode o "CI local":
+
+   ```sh
+   uv run ruff check . && \
+   uv run ruff format --check . && \
+   uv run mypy acelerado && \
+   uv run pytest
+   ```
+
+   Se algo falhar, ajusta. CI no GitHub Actions roda exatamente isso em PRs/pushes pra `main`.
+3. **Commit**: mensagem descritiva, idealmente referenciando a issue (`closes #N` no body fecha automaticamente no merge).
+4. **PR**: descrição clara, checklist de smoke tests, espera review.
+
+## Convenções
+
+### Idioma
+- **UI / Discord**: PT-BR (mensagens, role names, comandos).
+- **Código** (variáveis, funções, comentários, docstrings, mensagens de log): inglês.
+
+### Logging
+Cada módulo declara seu logger:
+```python
+import logging
+logger = logging.getLogger(__name__)
+```
+Não importe um `logger` compartilhado de `acelerado.log` — o handler global é configurado uma vez via `setup_logging()` no callback do typer.
+
+### Testes
+Tudo offline. Discord e Google YouTube API são mockados via fixtures de `tests/conftest.py`:
+- `fake_bot`, `fake_guild` — stand-ins de `commands.Bot` / `discord.Guild`.
+- `make_video_fn`, `make_playlist_item_fn` — builders de payload.
+- `_fake_youtube_client()` em `tests/test_youtube.py` — mock encadeável da Google API.
+
+Nunca abra socket, nunca dispara OAuth.
+
+### Contrato fail-proof
+Toda corotina dentro de um tick (passos do `event_loop`) **não deve raise** — falhas devem cair em `state.report_error("contexto", exc)`, que loga local e posta no canal de log do Discord (com cooldown de 10 min). O guard externo em `bot.event_loop_task` é a última rede; não confie nele pra lógica.
+
+Veja `CLAUDE.md` ("Fail-proof contract") pra detalhes.
+
+### Slash commands
+Vão em `acelerado/slash.py` ou módulos próprios. Pra adicionar um novo:
+
+1. Definir com `@app_commands.command(...)`.
+2. `tree.add_command(seu_cmd, guild=guild)` no `register_commands`.
+3. Teste de registro em `tests/test_slash.py` (ou módulo afim).
+4. Documentar no README.
+
+## Tarefas iniciais
+
+Issues marcadas com **`good first issue`** são bem delimitadas e ótimas pra começar — geralmente self-contained, com critérios de aceite claros e cobertura de teste pequena.
+
+## Contexto profundo
+
+[`CLAUDE.md`](./CLAUDE.md) tem o overview arquitetural — stack, layout, contratos, e gotchas. Vale a leitura antes de mexer em algo grande.
+
+## Reportando bugs
+
+Issue com:
+- **O que aconteceu** vs. o que era esperado.
+- **Como reproduzir** (passos + comando, se possível).
+- **Stack trace** completo. Rodar com `--log-level DEBUG` ajuda muito.
+- Versão do Python, do bot (commit hash) e SO.
+
+## Código de conduta
+
+Seja gentil. Aqui é uma comunidade de gente curiosa que gosta de programação de baixo nível e cafezinho.
+
+Obrigado!

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ uv sync
 | `/report` | Reportar uma mensagem aos mods. Recebe link da mensagem (Copy Message Link) + motivo. Rate-limit de 3 reports / 10min por usuário. |
 | `/preview-summary` | (admin) Posta o rascunho do resumo semanal **agora** no canal de review (botões pra Aprovar / Editar / Descartar). |
 | `/preview-stale` | (admin) Posta a lista de apoiadores stale **agora** no canal de mods. |
-| `/godbolt` | Gera link do [Compiler Explorer](https://godbolt.org) com seu código pré-carregado. Suporta C, C++, Rust, Zig, Go. |
+| `/godbolt` | Gera link do [Compiler Explorer](https://godbolt.org) com seu código pré-carregado. Suporta C, C++, Rust, Zig, Go, Python, JavaScript, Java, Haskell, Odin. |
 
 Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ uv sync
 | `/report` | Reportar uma mensagem aos mods. Recebe link da mensagem (Copy Message Link) + motivo. Rate-limit de 3 reports / 10min por usuário. |
 | `/preview-summary` | (admin) Posta o rascunho do resumo semanal **agora** no canal de review (botões pra Aprovar / Editar / Descartar). |
 | `/preview-stale` | (admin) Posta a lista de apoiadores stale **agora** no canal de mods. |
+| `/godbolt` | Gera link do [Compiler Explorer](https://godbolt.org) com seu código pré-carregado. Suporta C, C++, Rust, Zig, Go. |
 
 Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,53 @@ uv sync
 
    Na primeira execução que precisar da API do YouTube (por ex. `acelerado run` ou `acelerado refresh-token`), o navegador abrirá para consentimento e o token será salvo em `token.pickle`.
 
+## Como obter as credenciais
+
+Passo-a-passo pra preencher tudo do zero. Se você já tem app de bot no Discord e projeto no Google Cloud, pula direto pra "Pegando os IDs do servidor" no fim.
+
+### Discord — bot + token + intent
+
+1. Acesse o [Discord Developer Portal](https://discord.com/developers/applications) e clique em **New Application**.
+2. Dê um nome, aceite os termos.
+3. Na navegação à esquerda, vá em **Bot**:
+   - Clique em **Reset Token** e copie o valor — vira o seu `DISCORD_TOKEN` no `.env`. **Esse token nunca deve ser compartilhado nem commitado.**
+   - Em **Privileged Gateway Intents**, ligue **Server Members Intent** (necessário pra sincronização de cargos).
+4. Em **OAuth2 → URL Generator** (menu esquerdo):
+   - **Scopes**: marque `bot` e `applications.commands`.
+   - **Bot Permissions**: marque pelo menos `Send Messages`, `Manage Messages` (pra anti-spam de invites), `Manage Roles` (pra adicionar `Registradores`), `Read Messages/View Channels`, `Create Public Threads` (pra auto-thread em anúncios).
+   - Copie a URL gerada e abra num navegador logado na sua conta Discord. Selecione o servidor onde o bot vai entrar e autorize.
+
+### Google Cloud — OAuth + API key
+
+1. Acesse o [Google Cloud Console](https://console.cloud.google.com/) e crie (ou selecione) um projeto.
+2. Em **APIs e Serviços → Biblioteca**, busque **YouTube Data API v3** e clique em **Ativar**.
+3. **Tela de consentimento OAuth**: configure como "Externo" (mesmo se for só pra você), preencha nome do app e e-mail de suporte. Em "Usuários de teste", adicione o e-mail do dono do canal do YouTube.
+4. **APIs e Serviços → Credenciais**:
+   - **Criar credenciais → ID do cliente OAuth** → tipo de aplicativo "App para computador". Baixe o JSON e renomeie pra `credentials.json` na raiz do repo.
+   - **Criar credenciais → Chave de API** → copia a chave; vira o `YOUTUBE_API_KEY` no `.env`. Se quiser, restrinja a chave à YouTube Data API v3.
+
+### IDs do servidor (Discord) e do canal (YouTube)
+
+**Discord — habilite o Modo de Desenvolvedor**:
+- Configurações do usuário → Avançado → ligue "Modo de desenvolvedor".
+- Agora clique-direito em qualquer servidor / canal / cargo → **Copiar ID**.
+- Pra `DISCORD_GUILD_ID`: clique-direito no nome do servidor → Copiar ID.
+- Pra `DISCORD_ANNOUNCE_CHANNEL_ID` / `DISCORD_LOG_CHANNEL_ID` / `DISCORD_WELCOME_CHANNEL_ID` / `DISCORD_MODS_CHANNEL_ID` / `DISCORD_REVIEW_CHANNEL_ID`: clique-direito no canal → Copiar ID.
+
+**YouTube — `YOUTUBE_CHANNEL_ID`**:
+- Painel de criador (`studio.youtube.com`) → Configurações → Canal → ID do canal. Começa com `UC...`.
+- Ou: na URL do seu canal `youtube.com/channel/UCxxxxxx`, é o segmento depois de `/channel/`.
+
+### Primeiro consentimento
+
+Na primeira vez que rodar algo que toca a API privada do YouTube (membros, vídeos não-listados):
+
+```sh
+uv run acelerado refresh-token
+```
+
+Vai abrir o navegador. Faça login com a conta do criador (a mesma cadastrada como "usuário de teste" na tela de consentimento OAuth). O token vai pra `token.pickle`. A partir daí, `acelerado run` funciona sem nova interação.
+
 ## Slash commands no Discord
 
 | Comando | Descrição |
@@ -215,6 +262,8 @@ token.pickle      # token OAuth em cache (gitignored)
 ```
 
 ## Como contribuir
+
+Veja [CONTRIBUTING.md](./CONTRIBUTING.md) pra um guia rápido (setup, padrões, workflow). Resumo:
 
 1. Faça um fork deste repositório.
 2. Clone o seu fork:

--- a/acelerado/godbolt.py
+++ b/acelerado/godbolt.py
@@ -1,0 +1,74 @@
+"""Build Compiler Explorer (godbolt.org) ``clientstate`` URLs.
+
+The clientstate format encodes a JSON payload as URL-safe base64. We
+only emit single-session, single-compiler URLs — enough for
+``/godbolt`` to drop the user into a ready-to-tweak playground.
+
+Compiler IDs are Godbolt internals and may rotate over time. If a
+link stops loading the right compiler, update :data:`COMPILERS`.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+
+GODBOLT_BASE = "https://godbolt.org/clientstate/"
+
+
+@dataclass(frozen=True)
+class _Lang:
+    display: str  # what users see in the slash command picker
+    api_key: str  # Godbolt's "language" identifier
+    compiler: str  # Godbolt's compiler id
+
+
+# Edit here to add languages or update compilers.
+LANGUAGES: dict[str, _Lang] = {
+    "c": _Lang(display="C", api_key="c", compiler="cg132"),
+    "c++": _Lang(display="C++", api_key="c++", compiler="g132"),
+    "cpp": _Lang(display="C++ (alias cpp)", api_key="c++", compiler="g132"),
+    "rust": _Lang(display="Rust", api_key="rust", compiler="r1830"),
+    "zig": _Lang(display="Zig", api_key="zig", compiler="z0140"),
+    "go": _Lang(display="Go", api_key="go", compiler="gccgo132"),
+}
+
+
+def supported_keys() -> list[str]:
+    """Lowercase language keys accepted by :func:`build_clientstate_url`."""
+    # Stable order for consistent error messages.
+    return sorted(LANGUAGES)
+
+
+def build_clientstate_url(language: str, source: str) -> str:
+    """Return a ``godbolt.org/clientstate/<...>`` URL pre-loaded with the source.
+
+    Raises ``ValueError`` if the language isn't in :data:`LANGUAGES`.
+    """
+    lang = LANGUAGES.get(language.lower())
+    if lang is None:
+        raise ValueError(f"linguagem não suportada: {language!r}")
+
+    state = {
+        "sessions": [
+            {
+                "id": 1,
+                "language": lang.api_key,
+                "source": source,
+                "compilers": [{"id": lang.compiler, "options": ""}],
+            }
+        ]
+    }
+    encoded = base64.urlsafe_b64encode(
+        json.dumps(state, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    return GODBOLT_BASE + encoded
+
+
+def decode_clientstate_url(url: str) -> dict:
+    """Inverse of :func:`build_clientstate_url`. Used by tests + debugging."""
+    if not url.startswith(GODBOLT_BASE):
+        raise ValueError(f"not a clientstate URL: {url}")
+    encoded = url[len(GODBOLT_BASE) :]
+    return json.loads(base64.urlsafe_b64decode(encoded).decode("utf-8"))

--- a/acelerado/godbolt.py
+++ b/acelerado/godbolt.py
@@ -24,7 +24,11 @@ class _Lang:
     compiler: str  # Godbolt's compiler id
 
 
-# Edit here to add languages or update compilers.
+# Edit here to add languages or update compilers. Compiler IDs come from
+# Godbolt — go to https://godbolt.org, pick the language + compiler,
+# inspect the URL: ``/api/compilers/<lang>`` lists the IDs. They rotate
+# as new versions ship; if a link stops opening the right compiler,
+# update the ``compiler`` field below.
 LANGUAGES: dict[str, _Lang] = {
     "c": _Lang(display="C", api_key="c", compiler="cg132"),
     "c++": _Lang(display="C++", api_key="c++", compiler="g132"),
@@ -32,6 +36,12 @@ LANGUAGES: dict[str, _Lang] = {
     "rust": _Lang(display="Rust", api_key="rust", compiler="r1830"),
     "zig": _Lang(display="Zig", api_key="zig", compiler="z0140"),
     "go": _Lang(display="Go", api_key="go", compiler="gccgo132"),
+    "python": _Lang(display="Python", api_key="python", compiler="python313"),
+    "javascript": _Lang(display="JavaScript", api_key="javascript", compiler="v8node2210"),
+    "js": _Lang(display="JavaScript (alias js)", api_key="javascript", compiler="v8node2210"),
+    "java": _Lang(display="Java", api_key="java", compiler="java2200"),
+    "haskell": _Lang(display="Haskell", api_key="haskell", compiler="ghc984"),
+    "odin": _Lang(display="Odin", api_key="odin", compiler="odintrunk"),
 }
 
 

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -143,7 +143,7 @@ _MESSAGE_LINK_RE = re.compile(r"https?://(?:\w+\.)?discord\.com/channels/(\d+)/(
     description="Gera link do Compiler Explorer com seu código",
 )
 @app_commands.describe(
-    language="Linguagem do código (c, c++, rust, zig, go)",
+    language="Linguagem do código",
     code="Código (até ~3000 chars)",
 )
 @app_commands.choices(
@@ -153,6 +153,11 @@ _MESSAGE_LINK_RE = re.compile(r"https?://(?:\w+\.)?discord\.com/channels/(\d+)/(
         app_commands.Choice(name="Rust", value="rust"),
         app_commands.Choice(name="Zig", value="zig"),
         app_commands.Choice(name="Go", value="go"),
+        app_commands.Choice(name="Python", value="python"),
+        app_commands.Choice(name="JavaScript", value="javascript"),
+        app_commands.Choice(name="Java", value="java"),
+        app_commands.Choice(name="Haskell", value="haskell"),
+        app_commands.Choice(name="Odin", value="odin"),
     ]
 )
 async def cmd_godbolt(

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -138,6 +138,50 @@ async def _delayed_exit(code: int, delay_seconds: float = 3.0) -> None:
 _MESSAGE_LINK_RE = re.compile(r"https?://(?:\w+\.)?discord\.com/channels/(\d+)/(\d+)/(\d+)")
 
 
+@app_commands.command(
+    name="godbolt",
+    description="Gera link do Compiler Explorer com seu código",
+)
+@app_commands.describe(
+    language="Linguagem do código (c, c++, rust, zig, go)",
+    code="Código (até ~3000 chars)",
+)
+@app_commands.choices(
+    language=[
+        app_commands.Choice(name="C", value="c"),
+        app_commands.Choice(name="C++", value="c++"),
+        app_commands.Choice(name="Rust", value="rust"),
+        app_commands.Choice(name="Zig", value="zig"),
+        app_commands.Choice(name="Go", value="go"),
+    ]
+)
+async def cmd_godbolt(
+    interaction: discord.Interaction,
+    language: app_commands.Choice[str],
+    code: str,
+) -> None:
+    from acelerado import godbolt
+
+    try:
+        url = godbolt.build_clientstate_url(language.value, code)
+    except ValueError as exc:
+        await interaction.response.send_message(
+            f"⚠️ {exc}. Suportadas: {', '.join(godbolt.supported_keys())}",
+            ephemeral=True,
+        )
+        return
+
+    embed = discord.Embed(
+        title=f"🔗 Compiler Explorer — {language.name}",
+        description=f"[Abrir no godbolt.org]({url})",
+        color=discord.Color.dark_orange(),
+    )
+    embed.add_field(name="Snippet", value=f"```{language.value}\n{code[:500]}\n```", inline=False)
+    if len(code) > 500:
+        embed.set_footer(text=f"(snippet truncado — {len(code)} chars no link)")
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
 @app_commands.command(name="report", description="Reportar uma mensagem aos mods")
 @app_commands.describe(
     message_link="Link da mensagem (clique-direito → Copy Message Link)",
@@ -209,3 +253,4 @@ def register_commands(
     tree.add_command(cmd_report, guild=guild)
     tree.add_command(cmd_preview_summary, guild=guild)
     tree.add_command(cmd_preview_stale, guild=guild)
+    tree.add_command(cmd_godbolt, guild=guild)

--- a/acelerado/updater.py
+++ b/acelerado/updater.py
@@ -59,9 +59,7 @@ def _run(cmd: list[str], cwd: Path, timeout: float = _DEFAULT_TIMEOUT) -> tuple[
     ``timeout(1)``) so callers can tell it apart from a normal non-zero exit.
     """
     try:
-        proc = subprocess.run(
-            cmd, capture_output=True, text=True, cwd=str(cwd), timeout=timeout
-        )
+        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(cwd), timeout=timeout)
     except subprocess.TimeoutExpired:
         return 124, "", f"timed out after {timeout:.0f}s"
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()

--- a/tests/test_godbolt.py
+++ b/tests/test_godbolt.py
@@ -1,0 +1,51 @@
+"""Tests for ``acelerado.godbolt`` URL builder."""
+
+from __future__ import annotations
+
+import pytest
+
+from acelerado import godbolt
+
+
+def test_supported_keys_includes_known_languages():
+    keys = godbolt.supported_keys()
+    assert {"c", "c++", "rust", "zig", "go"} <= set(keys)
+
+
+@pytest.mark.parametrize("lang", ["c", "c++", "rust", "zig", "go"])
+def test_build_url_returns_clientstate(lang):
+    url = godbolt.build_clientstate_url(lang, "hello")
+    assert url.startswith(godbolt.GODBOLT_BASE)
+
+
+def test_build_url_round_trip_preserves_source():
+    code = "int main() { return 42; }"
+    url = godbolt.build_clientstate_url("c", code)
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["source"] == code
+    assert state["sessions"][0]["language"] == "c"
+    assert state["sessions"][0]["compilers"][0]["id"] == godbolt.LANGUAGES["c"].compiler
+
+
+def test_build_url_handles_unicode_source():
+    code = 'fn main() { println!("olá, açaí 🥭"); }'
+    url = godbolt.build_clientstate_url("rust", code)
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["source"] == code
+
+
+def test_build_url_unknown_language_raises():
+    with pytest.raises(ValueError, match="não suportada"):
+        godbolt.build_clientstate_url("brainfuck", "+++.")
+
+
+def test_alias_cpp_maps_to_cpp():
+    url = godbolt.build_clientstate_url("cpp", "int x;")
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["language"] == "c++"
+
+
+def test_language_case_insensitive():
+    a = godbolt.build_clientstate_url("RUST", "x")
+    b = godbolt.build_clientstate_url("rust", "x")
+    assert a == b

--- a/tests/test_godbolt.py
+++ b/tests/test_godbolt.py
@@ -9,10 +9,38 @@ from acelerado import godbolt
 
 def test_supported_keys_includes_known_languages():
     keys = godbolt.supported_keys()
-    assert {"c", "c++", "rust", "zig", "go"} <= set(keys)
+    expected = {
+        "c",
+        "c++",
+        "rust",
+        "zig",
+        "go",
+        "python",
+        "javascript",
+        "js",
+        "java",
+        "haskell",
+        "odin",
+    }
+    assert expected <= set(keys)
 
 
-@pytest.mark.parametrize("lang", ["c", "c++", "rust", "zig", "go"])
+@pytest.mark.parametrize(
+    "lang",
+    [
+        "c",
+        "c++",
+        "rust",
+        "zig",
+        "go",
+        "python",
+        "javascript",
+        "js",
+        "java",
+        "haskell",
+        "odin",
+    ],
+)
 def test_build_url_returns_clientstate(lang):
     url = godbolt.build_clientstate_url(lang, "hello")
     assert url.startswith(godbolt.GODBOLT_BASE)
@@ -43,6 +71,12 @@ def test_alias_cpp_maps_to_cpp():
     url = godbolt.build_clientstate_url("cpp", "int x;")
     state = godbolt.decode_clientstate_url(url)
     assert state["sessions"][0]["language"] == "c++"
+
+
+def test_alias_js_maps_to_javascript():
+    url = godbolt.build_clientstate_url("js", "console.log(1)")
+    state = godbolt.decode_clientstate_url(url)
+    assert state["sessions"][0]["language"] == "javascript"
 
 
 def test_language_case_insensitive():

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -239,6 +239,33 @@ async def test_register_report_command():
     assert cmd.name == "report"
 
 
+def test_register_godbolt_command():
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    cmd = tree.get_command("godbolt", guild=guild)
+    assert cmd is not None
+    assert cmd.name == "godbolt"
+
+
+async def test_godbolt_command_returns_url_in_embed():
+    from discord import app_commands
+
+    from acelerado.slash import cmd_godbolt
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    choice = app_commands.Choice(name="C", value="c")
+    await cmd_godbolt.callback(interaction, language=choice, code="int main(){return 0;}")
+
+    interaction.response.send_message.assert_awaited_once()
+    embed = interaction.response.send_message.await_args.kwargs.get("embed")
+    assert embed is not None
+    assert "godbolt.org/clientstate/" in (embed.description or "")
+
+
 async def test_report_invalid_link_responds_with_warning():
     from acelerado.slash import cmd_report
 


### PR DESCRIPTION
**Stacked on #27.** Cumulative merge order: #20 → #21 → #22 → #23 → #24 → #25 → #26 → #27 → this.

Implementa #10. \`/godbolt\` recebe linguagem (dropdown) + código, devolve embed ephemeral com link \`godbolt.org/clientstate/<base64>\` pré-carregado com o snippet.

## Como funciona
\`acelerado/godbolt.py\` monta um JSON com \`{sessions: [{language, source, compilers: [{id, options}]}]}\`, codifica em urlsafe base64 e concatena com \`https://godbolt.org/clientstate/\`. Compilador default por linguagem na constante \`LANGUAGES\` (editável quando IDs do Godbolt rotacionarem).

## Linguagens iniciais
C, C++ (com alias \`cpp\`), Rust, Zig, Go. Adicionar mais = editar uma linha em \`LANGUAGES\`.

## Test plan
- [x] \`pytest\` 188/188 (175 → 188).
- [x] \`ruff\`, \`mypy\` clean.
- [ ] Smoke: \`/godbolt language:C code:\"int main(){ return 0; }\"\` → embed com link funcional que abre o godbolt já com o snippet e gcc selecionado.
- [ ] Smoke: linguagem fora da lista (não deveria aparecer no dropdown).
- [ ] Smoke: código com Unicode (acentos, emojis) preserva caracteres no godbolt.

Closes #10