### PR TITLE
docs: CONTRIBUTING.md + walkthrough de credenciais no README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Como contribuir
+
+Obrigado por considerar contribuir com o Acelerado! Esse guia é o caminho rápido.
+
+## Pré-requisitos
+
+- **Python 3.11+**
+- [`uv`](https://docs.astral.sh/uv/) — `pip install -U uv`
+- Conta no [Discord Developer Portal](https://discord.com/developers/applications) para criar um bot de testes.
+- (Opcional) Credenciais OAuth do Google + chave da YouTube Data API v3 — só se for mexer com a parte de YouTube.
+
+## Setup local
+
+```sh
+git clone https://github.com/seu-usuario/discord.git
+cd discord
+uv sync                                 # instala deps + dev deps
+cp .example.env .env                    # depois edite com seus valores
+cp credentials.example.json credentials.json   # depois cole o JSON da app Google
+```
+
+Veja a seção **"Como obter credenciais"** no [`README.md`](./README.md) pra um passo-a-passo de Discord + Google Cloud.
+
+## Workflow de contribuição
+
+1. **Branch**: `feat/<descrição-curta>`, `fix/<bug>`, `docs/<o-que>`.
+2. **Antes de commitar**, rode o "CI local":
+
+   ```sh
+   uv run ruff check . && \
+   uv run ruff format --check . && \
+   uv run mypy acelerado && \
+   uv run pytest
+   ```
+
+   Se algo falhar, ajusta. CI no GitHub Actions roda exatamente isso em PRs/pushes pra `main`.
+3. **Commit**: mensagem descritiva, idealmente referenciando a issue (`closes #N` no body fecha automaticamente no merge).
+4. **PR**: descrição clara, checklist de smoke tests, espera review.
+
+## Convenções
+
+### Idioma
+- **UI / Discord**: PT-BR (mensagens, role names, comandos).
+- **Código** (variáveis, funções, comentários, docstrings, mensagens de log): inglês.
+
+### Logging
+Cada módulo declara seu logger:
+```python
+import logging
+logger = logging.getLogger(__name__)
+```
+Não importe um `logger` compartilhado de `acelerado.log` — o handler global é configurado uma vez via `setup_logging()` no callback do typer.
+
+### Testes
+Tudo offline. Discord e Google YouTube API são mockados via fixtures de `tests/conftest.py`:
+- `fake_bot`, `fake_guild` — stand-ins de `commands.Bot` / `discord.Guild`.
+- `make_video_fn`, `make_playlist_item_fn` — builders de payload.
+- `_fake_youtube_client()` em `tests/test_youtube.py` — mock encadeável da Google API.
+
+Nunca abra socket, nunca dispara OAuth.
+
+### Contrato fail-proof
+Toda corotina dentro de um tick (passos do `event_loop`) **não deve raise** — falhas devem cair em `state.report_error("contexto", exc)`, que loga local e posta no canal de log do Discord (com cooldown de 10 min). O guard externo em `bot.event_loop_task` é a última rede; não confie nele pra lógica.
+
+Veja `CLAUDE.md` ("Fail-proof contract") pra detalhes.
+
+### Slash commands
+Vão em `acelerado/slash.py` ou módulos próprios. Pra adicionar um novo:
+
+1. Definir com `@app_commands.command(...)`.
+2. `tree.add_command(seu_cmd, guild=guild)` no `register_commands`.
+3. Teste de registro em `tests/test_slash.py` (ou módulo afim).
+4. Documentar no README.
+
+## Tarefas iniciais
+
+Issues marcadas com **`good first issue`** são bem delimitadas e ótimas pra começar — geralmente self-contained, com critérios de aceite claros e cobertura de teste pequena.
+
+## Contexto profundo
+
+[`CLAUDE.md`](./CLAUDE.md) tem o overview arquitetural — stack, layout, contratos, e gotchas. Vale a leitura antes de mexer em algo grande.
+
+## Reportando bugs
+
+Issue com:
+- **O que aconteceu** vs. o que era esperado.
+- **Como reproduzir** (passos + comando, se possível).
+- **Stack trace** completo. Rodar com `--log-level DEBUG` ajuda muito.
+- Versão do Python, do bot (commit hash) e SO.
+
+## Código de conduta
+
+Seja gentil. Aqui é uma comunidade de gente curiosa que gosta de programação de baixo nível e cafezinho.
+
+Obrigado!

--- a/README.md
+++ b/README.md
@@ -63,6 +63,53 @@ uv sync
 
    Na primeira execução que precisar da API do YouTube (por ex. `acelerado run` ou `acelerado refresh-token`), o navegador abrirá para consentimento e o token será salvo em `token.pickle`.
 
+## Como obter as credenciais
+
+Passo-a-passo pra preencher tudo do zero. Se você já tem app de bot no Discord e projeto no Google Cloud, pula direto pra "Pegando os IDs do servidor" no fim.
+
+### Discord — bot + token + intent
+
+1. Acesse o [Discord Developer Portal](https://discord.com/developers/applications) e clique em **New Application**.
+2. Dê um nome, aceite os termos.
+3. Na navegação à esquerda, vá em **Bot**:
+   - Clique em **Reset Token** e copie o valor — vira o seu `DISCORD_TOKEN` no `.env`. **Esse token nunca deve ser compartilhado nem commitado.**
+   - Em **Privileged Gateway Intents**, ligue **Server Members Intent** (necessário pra sincronização de cargos).
+4. Em **OAuth2 → URL Generator** (menu esquerdo):
+   - **Scopes**: marque `bot` e `applications.commands`.
+   - **Bot Permissions**: marque pelo menos `Send Messages`, `Manage Messages` (pra anti-spam de invites), `Manage Roles` (pra adicionar `Registradores`), `Read Messages/View Channels`, `Create Public Threads` (pra auto-thread em anúncios).
+   - Copie a URL gerada e abra num navegador logado na sua conta Discord. Selecione o servidor onde o bot vai entrar e autorize.
+
+### Google Cloud — OAuth + API key
+
+1. Acesse o [Google Cloud Console](https://console.cloud.google.com/) e crie (ou selecione) um projeto.
+2. Em **APIs e Serviços → Biblioteca**, busque **YouTube Data API v3** e clique em **Ativar**.
+3. **Tela de consentimento OAuth**: configure como "Externo" (mesmo se for só pra você), preencha nome do app e e-mail de suporte. Em "Usuários de teste", adicione o e-mail do dono do canal do YouTube.
+4. **APIs e Serviços → Credenciais**:
+   - **Criar credenciais → ID do cliente OAuth** → tipo de aplicativo "App para computador". Baixe o JSON e renomeie pra `credentials.json` na raiz do repo.
+   - **Criar credenciais → Chave de API** → copia a chave; vira o `YOUTUBE_API_KEY` no `.env`. Se quiser, restrinja a chave à YouTube Data API v3.
+
+### IDs do servidor (Discord) e do canal (YouTube)
+
+**Discord — habilite o Modo de Desenvolvedor**:
+- Configurações do usuário → Avançado → ligue "Modo de desenvolvedor".
+- Agora clique-direito em qualquer servidor / canal / cargo → **Copiar ID**.
+- Pra `DISCORD_GUILD_ID`: clique-direito no nome do servidor → Copiar ID.
+- Pra `DISCORD_ANNOUNCE_CHANNEL_ID` / `DISCORD_LOG_CHANNEL_ID` / `DISCORD_WELCOME_CHANNEL_ID` / `DISCORD_MODS_CHANNEL_ID` / `DISCORD_REVIEW_CHANNEL_ID`: clique-direito no canal → Copiar ID.
+
+**YouTube — `YOUTUBE_CHANNEL_ID`**:
+- Painel de criador (`studio.youtube.com`) → Configurações → Canal → ID do canal. Começa com `UC...`.
+- Ou: na URL do seu canal `youtube.com/channel/UCxxxxxx`, é o segmento depois de `/channel/`.
+
+### Primeiro consentimento
+
+Na primeira vez que rodar algo que toca a API privada do YouTube (membros, vídeos não-listados):
+
+```sh
+uv run acelerado refresh-token
+```
+
+Vai abrir o navegador. Faça login com a conta do criador (a mesma cadastrada como "usuário de teste" na tela de consentimento OAuth). O token vai pra `token.pickle`. A partir daí, `acelerado run` funciona sem nova interação.
+
 ## Slash commands no Discord
 
 | Comando | Descrição |
@@ -215,6 +262,8 @@ token.pickle      # token OAuth em cache (gitignored)
 ```
 
 ## Como contribuir
+
+Veja [CONTRIBUTING.md](./CONTRIBUTING.md) pra um guia rápido (setup, padrões, workflow). Resumo:
 
 1. Faça um fork deste repositório.
 2. Clone o seu fork:


### PR DESCRIPTION
**Stacked on #28.** Cumulative merge order: #20 → #21 → #22 → #23 → #24 → #25 → #26 → #27 → #28 → this. **Última PR da stack.**

Implementa #15 e #4 — ambos pure-docs.

## CONTRIBUTING.md (#15)
Guia rápido em PT-BR cobrindo:
- Pré-requisitos (Python 3.11+, uv).
- Setup local (\`uv sync\`, \`.env\`, \`credentials.json\`).
- Workflow: branch → CI local (\`ruff + mypy + pytest\`) → commit \`closes #N\` → PR.
- Convenções: UI em PT-BR, código em inglês, \`logger = logging.getLogger(__name__)\` por módulo, contrato fail-proof.
- Padrão pra adicionar slash commands.
- Apontamento pra \`good first issue\` e \`CLAUDE.md\`.

## README — "Como obter as credenciais" (#4)
Passo-a-passo do zero pra preencher \`.env\` e \`credentials.json\`:
- **Discord**: criar app, pegar token, ligar Server Members intent, OAuth2 URL Generator com scopes/permissões mínimas (incluindo Manage Roles, Create Public Threads etc).
- **Google Cloud**: ativar YouTube Data API v3, tela de consentimento OAuth, criar OAuth client (Desktop App) → \`credentials.json\`, criar API key → \`YOUTUBE_API_KEY\`.
- **IDs**: habilitar Modo Desenvolvedor no Discord pra clicar-direito → Copiar ID; explicação de \`YOUTUBE_CHANNEL_ID\`.
- **Primeiro consentimento** via \`acelerado refresh-token\`.

## Test plan
- [x] \`pytest\` 188/188 (sem código novo, mas validação que nada quebrou).
- [ ] Leitura humana: alguém que nunca configurou consegue rodar o bot só seguindo o README + CONTRIBUTING?

Closes #15
Closes #4