### PR TITLE
refactor(state): quality pass — announce ordering, extracted helpers, aware UTC

### DIFF
--- a/acelerado/bot.py
+++ b/acelerado/bot.py
@@ -1,5 +1,7 @@
 import datetime as _dt
 import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import discord
@@ -101,23 +103,31 @@ class AceleradoBot(commands.Bot):
         await self.wait_until_ready()
         if self.state_handler is None:
             self.state_handler = AceleradoState(self)
+            await self.state_handler.warm_up()
 
     # ------------------------------------------------------------------
     # Weekly scheduled drafts (run Monday 9am SP)
     # ------------------------------------------------------------------
 
-    @tasks.loop(time=[_MON_9AM_SP])
-    async def weekly_summary_task(self) -> None:
+    async def _run_weekly(
+        self,
+        name: str,
+        fn: Callable[[commands.Bot], Awaitable[Any]],
+    ) -> None:
         # discord.py's tasks.loop with `time=` fires daily at that time;
         # gate to Mondays only.
         if _dt.datetime.now(_MON_9AM_SP.tzinfo).weekday() != 0:
             return
         try:
-            await review.post_weekly_summary_draft(self)
+            await fn(self)
         except Exception as exc:
-            logger.exception("weekly_summary_task failed")
+            logger.exception(f"{name} weekly task failed")
             if self.state_handler is not None:
-                await self.state_handler.report_error("weekly_summary", exc)
+                await self.state_handler.report_error(name, exc)
+
+    @tasks.loop(time=[_MON_9AM_SP])
+    async def weekly_summary_task(self) -> None:
+        await self._run_weekly("weekly_summary", review.post_weekly_summary_draft)
 
     @weekly_summary_task.before_loop
     async def _before_weekly_summary(self) -> None:
@@ -125,14 +135,7 @@ class AceleradoBot(commands.Bot):
 
     @tasks.loop(time=[_MON_9AM_SP])
     async def weekly_stale_task(self) -> None:
-        if _dt.datetime.now(_MON_9AM_SP.tzinfo).weekday() != 0:
-            return
-        try:
-            await review.post_stale_report(self)
-        except Exception as exc:
-            logger.exception("weekly_stale_task failed")
-            if self.state_handler is not None:
-                await self.state_handler.report_error("weekly_stale", exc)
+        await self._run_weekly("weekly_stale", review.post_stale_report)
 
     @weekly_stale_task.before_loop
     async def _before_weekly_stale(self) -> None:

--- a/acelerado/error_reporter.py
+++ b/acelerado/error_reporter.py
@@ -1,0 +1,57 @@
+"""Rate-limited error reporting to Discord.
+
+Pulled out of ``AceleradoState`` so the cooldown logic is testable in
+isolation and so the same reporter can be reused by other parts of the
+bot (e.g. weekly tasks) without dragging the whole state with them.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+import discord
+
+from acelerado import metrics
+
+logger = logging.getLogger(__name__)
+
+# How often we're willing to post a "something blew up" report to Discord.
+# Local logs are always emitted; this only throttles the remote notification
+# so a broken tick doesn't spam the log channel every 5 minutes.
+ERROR_REPORT_COOLDOWN = timedelta(minutes=10)
+
+
+ChannelGetter = Callable[[], "discord.abc.Messageable | None"]
+
+
+class ErrorReporter:
+    """Logs locally, optionally posts to a Discord channel with cooldown."""
+
+    def __init__(self, channel_getter: ChannelGetter) -> None:
+        self._get_channel = channel_getter
+        self.last_report = datetime.now(UTC) - timedelta(days=7)
+
+    async def report(self, context: str, exc: BaseException) -> None:
+        logger.exception(f"[{context}] {type(exc).__name__}: {exc}", exc_info=exc)
+        metrics.increment("errors", context=context)
+
+        now = datetime.now(UTC)
+        if now - self.last_report < ERROR_REPORT_COOLDOWN:
+            return
+        self.last_report = now
+
+        channel = self._get_channel()
+        if channel is None:
+            return
+
+        summary = f"⚠️ Erro em `{context}`: `{type(exc).__name__}: {exc}`"
+        # Discord caps messages at 2000 chars; leave headroom.
+        if len(summary) > 1900:
+            summary = summary[:1900] + "…"
+        try:
+            await channel.send(summary)
+        except Exception:
+            # A failing notifier must never bubble up — we already logged locally.
+            logger.exception("Failed to deliver error report to Discord log channel")

--- a/acelerado/metrics.py
+++ b/acelerado/metrics.py
@@ -47,15 +47,32 @@ class Metrics(BaseModel):
 # Persistence
 # ---------------------------------------------------------------------------
 
+# Path-keyed in-process cache. The bot is the only process writing to a
+# given metrics file, so we can keep the parsed object in memory and skip
+# the load/parse step on every increment. Disk writes still happen so
+# external readers (TUI, healthcheck) see fresh data.
+_cache: dict[Path, Metrics] = {}
+
+
+def reset_cache() -> None:
+    """Test helper — drop the in-process metrics cache."""
+    _cache.clear()
+
 
 def load(path: Path = METRICS_PATH) -> Metrics:
+    cached = _cache.get(path)
+    if cached is not None:
+        return cached
     if not path.exists():
-        return Metrics()
-    try:
-        return Metrics.model_validate_json(path.read_text(encoding="utf-8"))
-    except Exception as exc:
-        logger.warning(f"metrics.json corrupted ({exc}); starting fresh")
-        return Metrics()
+        m = Metrics()
+    else:
+        try:
+            m = Metrics.model_validate_json(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning(f"metrics.json corrupted ({exc}); starting fresh")
+            m = Metrics()
+    _cache[path] = m
+    return m
 
 
 def _atomic_write(path: Path, data: str) -> None:
@@ -65,6 +82,7 @@ def _atomic_write(path: Path, data: str) -> None:
 
 
 def save(m: Metrics, path: Path = METRICS_PATH) -> None:
+    _cache[path] = m
     _atomic_write(path, m.model_dump_json(indent=2))
 
 

--- a/acelerado/review.py
+++ b/acelerado/review.py
@@ -48,20 +48,9 @@ def build_weekly_summary_text(videos: list[dict], window: timedelta = SUMMARY_WI
     """
     cutoff = datetime.now(UTC) - window
 
-    def _parse_published(video: dict) -> datetime | None:
-        raw = video.get("snippet", {}).get("publishedAt")
-        if not raw:
-            return None
-        if raw.endswith("Z"):
-            raw = raw[:-1] + "+00:00"
-        try:
-            return datetime.fromisoformat(raw)
-        except ValueError:
-            return None
-
     in_window: list[tuple[datetime, dict]] = []
     for v in videos:
-        when = _parse_published(v)
+        when = youtube.parse_iso8601_z(v.get("snippet", {}).get("publishedAt"))
         if when is not None and when >= cutoff:
             in_window.append((when, v))
     in_window.sort(key=lambda pair: pair[0], reverse=True)

--- a/acelerado/state.py
+++ b/acelerado/state.py
@@ -8,6 +8,9 @@ from discord.ext import commands
 
 from acelerado import metrics, youtube
 from acelerado.env import get_env
+from acelerado.error_reporter import ErrorReporter
+from acelerado.review import parse_username_whitelist
+from acelerado.store import LineSetStore
 
 logger = logging.getLogger(__name__)
 
@@ -18,21 +21,18 @@ FILENAME_PUBLISHED = Path("published.txt")
 LAST_TICK_PATH = Path("last_tick.txt")
 LIVE_REMINDERS_PATH = Path("live_reminders.txt")
 
-# How often we're willing to post a "something blew up" report to Discord.
-# Local logs are always emitted; this only throttles the remote notification
-# so a broken tick doesn't spam the log channel every 5 minutes.
-ERROR_REPORT_COOLDOWN = timedelta(minutes=10)
-
 
 class AceleradoState:
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        self.published = LineSetStore(FILENAME_PUBLISHED)
+        self.live_reminders = LineSetStore(LIVE_REMINDERS_PATH)
         # "Long enough ago that the first warning isn't rate-limited."
-        long_ago = datetime.now() - timedelta(days=7)
-        self.last_msg_expiry = long_ago
-        self._last_error_report = long_ago
+        self.last_msg_expiry = datetime.now(UTC) - timedelta(days=7)
+        self.error_reporter = ErrorReporter(lambda: self.channel_log)
 
-        self._initialize_videos_pubs()
+        # Channel validation only — cheap cache lookup, no I/O. Network /
+        # OAuth-triggering work happens in `warm_up`.
         if self.channel_log is None or self.channel_announce is None:
             raise ValueError(
                 f"Unable to get channels log={self.channel_log} announce={self.channel_announce}"
@@ -66,71 +66,43 @@ class AceleradoState:
     @property
     def videos_pubs(self) -> list[str]:
         """Non-empty, stripped IDs from ``published.txt``. Missing file -> []."""
-        if not FILENAME_PUBLISHED.exists():
-            return []
-        return [
-            line.strip() for line in FILENAME_PUBLISHED.read_text().splitlines() if line.strip()
-        ]
+        return self.published.read_all()
 
-    def _initialize_videos_pubs(self) -> None:
-        if not FILENAME_PUBLISHED.exists():
-            latest_videos = youtube.get_last_videos(max_videos=20)
-            video_ids = [youtube.get_video_id(v) for v in latest_videos]
-            FILENAME_PUBLISHED.write_text("\n".join(video_ids))
+    async def warm_up(self) -> None:
+        """First-run seeding. Called from the bot once the gateway is ready.
 
+        Kept out of ``__init__`` because it makes a YouTube API call (and
+        on a fresh deployment will trigger the OAuth browser flow), which
+        would otherwise block the gateway-ready callback.
+        """
+        if not FILENAME_PUBLISHED.exists():
+            try:
+                latest = youtube.get_last_videos(max_videos=20)
+                ids = [youtube.get_video_id(v) for v in latest]
+                FILENAME_PUBLISHED.write_text("\n".join(ids))
+            except Exception as exc:
+                await self.error_reporter.report("warm_up", exc)
+                return
         logger.info(f"Videos published on start: {self.videos_pubs}")
 
     def add_video_published(self, video_id: str) -> None:
         """Append ``video_id`` to ``published.txt``. No-op if already present."""
-        existing = set(self.videos_pubs)
-        if video_id in existing:
-            logger.debug(f"Video {video_id} already in published.txt, skipping append")
-            return
-        # Ensure the file exists — callers shouldn't have to care.
-        if not FILENAME_PUBLISHED.exists():
-            FILENAME_PUBLISHED.write_text("")
-        # Use a leading newline only when the file isn't empty/missing-trailing-nl.
-        current = FILENAME_PUBLISHED.read_text()
-        prefix = "" if not current or current.endswith("\n") else "\n"
-        with FILENAME_PUBLISHED.open("a") as f:
-            f.write(f"{prefix}{video_id}\n")
+        self.published.add(video_id)
 
     def check_videos_to_pub(self) -> list[str]:
-        published = set(self.videos_pubs)
-        return [
-            youtube.get_video_id(v)
-            for v in youtube.get_last_videos(max_videos=10)
-            if youtube.get_video_id(v) not in published
-        ]
+        published = self.published.as_set()
+        out: list[str] = []
+        for v in youtube.get_last_videos(max_videos=10):
+            vid = youtube.get_video_id(v)
+            if vid not in published:
+                out.append(vid)
+        return out
 
     # ------------------------------------------------------------------
-    # Announcement filtering
+    # Announcement
     # ------------------------------------------------------------------
-
-    def should_announce_video(self, video: dict) -> bool:
-        if youtube.is_non_listed(video):
-            return False
-        # Scheduled-but-not-yet-live: handled by _check_upcoming_lives
-        # (reminder), not here. Avoid announcing "Estamos em live!" before
-        # the live actually starts.
-        if youtube.is_livestream(video) and not youtube.is_live_now(video):
-            return False
-        if not youtube.is_processed(video) and not youtube.is_livestream(video):
-            return False
-        if youtube.is_vertical(video):
-            return False
-        return True
-
-    def get_video_state(self, video: dict) -> dict:
-        return {
-            "non-listed": youtube.is_non_listed(video),
-            "is-processed": youtube.is_processed(video),
-            "is-livestream": youtube.is_livestream(video),
-            "is-vertical": youtube.is_vertical(video),
-        }
 
     async def announce_video(self, video_id: str, video: dict) -> None:
-        self.add_video_published(video_id)
         if youtube.is_livestream(video):
             msg = "Estamos em live!"
         elif youtube.is_members_only(video):
@@ -145,7 +117,13 @@ class AceleradoState:
         if channel is None:
             logger.error("Announce channel disappeared from cache; cannot send")
             return
+        # Send first, then record. Recording before send risks marking a
+        # video "announced" when Discord rejected the message — the next
+        # tick would then skip it forever. The reverse failure (double-post
+        # if Discord accepted but we crash before recording) is louder and
+        # rarer.
         sent = await channel.send(msg_send)
+        self.add_video_published(video_id)
         metrics.increment("videos_announced", context=video_id)
 
         if get_env().ACELERADO_AUTO_THREAD:
@@ -177,11 +155,11 @@ class AceleradoState:
         if expiration_time is None or expiration_time >= (3600 * 24):
             return
 
-        diff_last_msg = (datetime.now() - self.last_msg_expiry).total_seconds()
+        diff_last_msg = (datetime.now(UTC) - self.last_msg_expiry).total_seconds()
         if diff_last_msg < 3600:
             return
 
-        self.last_msg_expiry = datetime.now()
+        self.last_msg_expiry = datetime.now(UTC)
         expiry_date = youtube.get_token_expiration_date()
         channel = self.channel_log
         if channel is None:
@@ -214,6 +192,7 @@ class AceleradoState:
             return 0
 
         chat_channel = discord.utils.get(guild.channels, name=CHAT_MSG_ADD)
+        whitelist = parse_username_whitelist(get_env().ACELERADO_APOIADORES_WHITELIST)
 
         # A member may appear in several YT-tier roles; dedupe before iterating.
         seen: set[int] = set()
@@ -226,7 +205,7 @@ class AceleradoState:
 
                 if apoiadores_role in member.roles:
                     continue
-                if member.name == "eniaw":
+                if member.name in whitelist:
                     continue
                 await member.add_roles(apoiadores_role)
                 added += 1
@@ -243,40 +222,12 @@ class AceleradoState:
         return added
 
     # ------------------------------------------------------------------
-    # Error reporting — local log + rate-limited Discord notification.
+    # Error reporting — thin wrapper around ErrorReporter to keep the
+    # public API stable for callers (welcome, slash commands, bot.py).
     # ------------------------------------------------------------------
 
     async def report_error(self, context: str, exc: BaseException) -> None:
-        """Log an error locally and, if not rate-limited, post to the log channel.
-
-        ``context`` is a short label for where the error came from so the
-        Discord message is readable at a glance.
-        """
-        logger.exception(f"[{context}] {type(exc).__name__}: {exc}", exc_info=exc)
-        metrics.increment("errors", context=context)
-
-        now = datetime.now()
-        if now - self._last_error_report < ERROR_REPORT_COOLDOWN:
-            return
-        self._last_error_report = now
-
-        channel = self.channel_log
-        if channel is None:
-            return
-
-        summary = f"⚠️ Erro em `{context}`: `{type(exc).__name__}: {exc}`"
-        # Discord caps messages at 2000 chars; leave headroom.
-        if len(summary) > 1900:
-            summary = summary[:1900] + "…"
-        try:
-            await channel.send(summary)
-        except Exception:
-            # A failing notifier must never bubble up — we already logged locally.
-            logger.exception("Failed to deliver error report to Discord log channel")
-
-    # ------------------------------------------------------------------
-    # Tick
-    # ------------------------------------------------------------------
+        await self.error_reporter.report(context, exc)
 
     # ------------------------------------------------------------------
     # Upcoming livestream reminders
@@ -285,25 +236,13 @@ class AceleradoState:
     @property
     def live_reminders_sent(self) -> set[str]:
         """Already-reminded video IDs from ``live_reminders.txt``."""
-        if not LIVE_REMINDERS_PATH.exists():
-            return set()
-        return {ln.strip() for ln in LIVE_REMINDERS_PATH.read_text().splitlines() if ln.strip()}
-
-    def _record_live_reminder(self, video_id: str) -> None:
-        if video_id in self.live_reminders_sent:
-            return
-        if not LIVE_REMINDERS_PATH.exists():
-            LIVE_REMINDERS_PATH.write_text("")
-        current = LIVE_REMINDERS_PATH.read_text()
-        prefix = "" if not current or current.endswith("\n") else "\n"
-        with LIVE_REMINDERS_PATH.open("a") as f:
-            f.write(f"{prefix}{video_id}\n")
+        return self.live_reminders.as_set()
 
     async def _check_upcoming_lives(self) -> None:
         """Send a "live em N min" reminder for any scheduled live within window."""
         now = datetime.now(UTC)
         window = timedelta(minutes=get_env().ACELERADO_LIVE_REMINDER_MINUTES)
-        sent = self.live_reminders_sent
+        sent = self.live_reminders.as_set()
 
         for vid in youtube.get_upcoming_livestream_ids():
             if vid in sent:
@@ -326,7 +265,7 @@ class AceleradoState:
                 logger.error("Announce channel disappeared; can't send live reminder")
                 return
             await channel.send(msg)
-            self._record_live_reminder(vid)
+            self.live_reminders.add(vid)
             logger.info(f"Posted live reminder for {vid} ({title})")
 
     async def _pub_new_videos(self) -> None:
@@ -334,13 +273,13 @@ class AceleradoState:
         for video_id in self.check_videos_to_pub():
             video = youtube.get_video_info(video_id)
             title = youtube.get_video_title(video)
-            if self.should_announce_video(video):
+            if youtube.should_announce_video(video):
                 logger.info(f"Announcing video {video_id} - '{title}'!")
                 await self.announce_video(video_id, video)
             else:
                 logger.info(
                     f"Not announcing video {video_id} - '{title}' yet "
-                    f"({self.get_video_state(video)})"
+                    f"({youtube.video_state_flags(video)})"
                 )
 
     async def event_loop(self) -> None:

--- a/acelerado/store.py
+++ b/acelerado/store.py
@@ -1,0 +1,37 @@
+"""File-backed unique-line set.
+
+``published.txt`` and ``live_reminders.txt`` both encode "set of IDs we've
+already done something about, one per line." This wraps the read / contains
+/ append-if-new pattern so the call sites stop re-implementing the
+trailing-newline dance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class LineSetStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def read_all(self) -> list[str]:
+        if not self.path.exists():
+            return []
+        return [ln.strip() for ln in self.path.read_text().splitlines() if ln.strip()]
+
+    def as_set(self) -> set[str]:
+        return set(self.read_all())
+
+    def __contains__(self, line: str) -> bool:
+        return line in self.as_set()
+
+    def add(self, line: str) -> bool:
+        """Append ``line`` if not already present. Returns True if added."""
+        if line in self.as_set():
+            return False
+        existing = self.path.read_text() if self.path.exists() else ""
+        sep = "" if not existing or existing.endswith("\n") else "\n"
+        with self.path.open("a") as f:
+            f.write(f"{sep}{line}\n")
+        return True

--- a/acelerado/youtube.py
+++ b/acelerado/youtube.py
@@ -137,9 +137,12 @@ def is_live_now(video: dict) -> bool:
     return "actualStartTime" in details and "actualEndTime" not in details
 
 
-def get_scheduled_start_time(video: dict) -> datetime | None:
-    """Return ``scheduledStartTime`` as aware UTC datetime, or None."""
-    raw = video.get("liveStreamingDetails", {}).get("scheduledStartTime")
+def parse_iso8601_z(raw: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp (incl. trailing ``Z``) to aware UTC.
+
+    Returns None for empty input or unparseable values; logs a warning for
+    the latter so silent format drift in YouTube payloads is visible.
+    """
     if not raw:
         return None
     if raw.endswith("Z"):
@@ -147,8 +150,14 @@ def get_scheduled_start_time(video: dict) -> datetime | None:
     try:
         return datetime.fromisoformat(raw)
     except ValueError:
-        logger.warning(f"Invalid scheduledStartTime format: {raw!r}")
+        logger.warning(f"Invalid ISO-8601 timestamp: {raw!r}")
         return None
+
+
+def get_scheduled_start_time(video: dict) -> datetime | None:
+    """Return ``scheduledStartTime`` as aware UTC datetime, or None."""
+    raw = video.get("liveStreamingDetails", {}).get("scheduledStartTime")
+    return parse_iso8601_z(raw)
 
 
 def get_upcoming_livestream_ids(max_results: int = 5) -> list[str]:
@@ -191,3 +200,32 @@ def is_vertical(video: dict) -> bool:
     width = stream.get("widthPixels", 0)
     height = stream.get("heightPixels", 0)
     return height > width
+
+
+def should_announce_video(video: dict) -> bool:
+    """True if the video passes every filter we apply before announcing.
+
+    Pure function — operates only on the YouTube payload shape.
+    """
+    if is_non_listed(video):
+        return False
+    # Scheduled-but-not-yet-live: handled by the live-reminder step, not
+    # here. Avoid announcing "Estamos em live!" before the live actually
+    # starts.
+    if is_livestream(video) and not is_live_now(video):
+        return False
+    if not is_processed(video) and not is_livestream(video):
+        return False
+    if is_vertical(video):
+        return False
+    return True
+
+
+def video_state_flags(video: dict) -> dict[str, bool]:
+    """Snapshot of the boolean flags consulted by :func:`should_announce_video`."""
+    return {
+        "non-listed": is_non_listed(video),
+        "is-processed": is_processed(video),
+        "is-livestream": is_livestream(video),
+        "is-vertical": is_vertical(video),
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,11 +43,13 @@ def chdir_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def clear_caches() -> None:
     """Reset lru_cache-backed singletons so tests don't leak state."""
     from acelerado import env as env_mod
+    from acelerado import metrics as metrics_mod
     from acelerado import youtube as yt_mod
 
     env_mod.get_env.cache_clear()
     yt_mod._youtube.cache_clear()
     yt_mod.get_upload_playlist_id.cache_clear()
+    metrics_mod.reset_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -34,18 +34,33 @@ def test_state_raises_when_channels_missing(chdir_tmp, fake_bot, monkeypatch):
         state_mod.AceleradoState(fake_bot)
 
 
-def test_state_seeds_published_file_on_first_run(
+async def test_warm_up_seeds_published_file_on_first_run(
     chdir_tmp, fake_bot, monkeypatch, make_playlist_item_fn
 ):
     items = [make_playlist_item_fn("a"), make_playlist_item_fn("b")]
     monkeypatch.setattr(yt_mod, "get_last_videos", lambda max_videos=20: items)
 
-    state_mod.AceleradoState(fake_bot)
+    state = state_mod.AceleradoState(fake_bot)
+    # Construction must NOT touch published.txt — that's warm_up's job.
+    assert not (chdir_tmp / "published.txt").exists()
+
+    await state.warm_up()
     assert (chdir_tmp / "published.txt").read_text().splitlines() == ["a", "b"]
 
 
+async def test_warm_up_reports_youtube_failure(chdir_tmp, fake_bot, fake_guild, monkeypatch):
+    def boom(max_videos: int = 20):
+        raise RuntimeError("youtube down")
+
+    monkeypatch.setattr(yt_mod, "get_last_videos", boom)
+    state = state_mod.AceleradoState(fake_bot)
+    # Should NOT raise — failure flows through report_error.
+    await state.warm_up()
+    fake_guild._log.send.assert_awaited()
+
+
 # ---------------------------------------------------------------------------
-# should_announce_video filtering
+# should_announce_video filtering (pure helpers — live in youtube module)
 # ---------------------------------------------------------------------------
 
 
@@ -56,29 +71,29 @@ def built_state(chdir_tmp, fake_bot, monkeypatch):
     return state_mod.AceleradoState(fake_bot)
 
 
-def test_announce_rules_public_processed_passes(built_state, make_video_fn):
-    assert built_state.should_announce_video(make_video_fn()) is True
+def test_announce_rules_public_processed_passes(make_video_fn):
+    assert yt_mod.should_announce_video(make_video_fn()) is True
 
 
-def test_announce_rules_skip_non_public(built_state, make_video_fn):
-    assert built_state.should_announce_video(make_video_fn(privacy_status="unlisted")) is False
+def test_announce_rules_skip_non_public(make_video_fn):
+    assert yt_mod.should_announce_video(make_video_fn(privacy_status="unlisted")) is False
 
 
-def test_announce_rules_skip_unprocessed_unless_live(built_state, make_video_fn):
+def test_announce_rules_skip_unprocessed_unless_live(make_video_fn):
     unprocessed = make_video_fn(upload_status="uploaded")
-    assert built_state.should_announce_video(unprocessed) is False
+    assert yt_mod.should_announce_video(unprocessed) is False
 
     live = make_video_fn(upload_status="uploaded", livestream=True)
-    assert built_state.should_announce_video(live) is True
+    assert yt_mod.should_announce_video(live) is True
 
 
-def test_announce_rules_skip_vertical(built_state, make_video_fn):
-    assert built_state.should_announce_video(make_video_fn(vertical=True)) is False
+def test_announce_rules_skip_vertical(make_video_fn):
+    assert yt_mod.should_announce_video(make_video_fn(vertical=True)) is False
 
 
-def test_video_state_returns_all_flags(built_state, make_video_fn):
-    state_dict = built_state.get_video_state(make_video_fn(livestream=True))
-    assert set(state_dict.keys()) == {
+def test_video_state_returns_all_flags(make_video_fn):
+    flags = yt_mod.video_state_flags(make_video_fn(livestream=True))
+    assert set(flags.keys()) == {
         "non-listed",
         "is-processed",
         "is-livestream",
@@ -240,7 +255,7 @@ async def test_check_expiration_rate_limits_to_one_per_hour(built_state, fake_gu
     assert fake_guild._log.send.await_count == 1
 
     # Force last_msg_expiry back in time; next call should warn again.
-    built_state.last_msg_expiry = datetime.now() - timedelta(hours=2)
+    built_state.last_msg_expiry = datetime.now(UTC) - timedelta(hours=2)
     await built_state.check_expiration()
     assert fake_guild._log.send.await_count == 2
 
@@ -463,18 +478,18 @@ async def test_check_upcoming_lives_dedups_across_ticks(
     assert "live1" in state_mod.LIVE_REMINDERS_PATH.read_text()
 
 
-def test_should_announce_skips_scheduled_but_not_started(built_state, make_video_fn):
+def test_should_announce_skips_scheduled_but_not_started(make_video_fn):
     video = make_video_fn(livestream=True)
     video["liveStreamingDetails"] = {"scheduledStartTime": "2099-01-01T00:00:00Z"}
-    assert built_state.should_announce_video(video) is False
+    assert yt_mod.should_announce_video(video) is False
 
 
-def test_should_announce_passes_for_started_live(built_state, make_video_fn):
+def test_should_announce_passes_for_started_live(make_video_fn):
     video = make_video_fn(livestream=True)
     video["liveStreamingDetails"] = {
         "actualStartTime": "2026-04-25T19:00:00Z",
     }
-    assert built_state.should_announce_video(video) is True
+    assert yt_mod.should_announce_video(video) is True
 
 
 async def test_event_loop_isolates_step_errors(built_state, monkeypatch):
@@ -643,11 +658,11 @@ async def test_report_error_rate_limited_within_cooldown(built_state, fake_guild
 
 
 async def test_report_error_resumes_after_cooldown(built_state, fake_guild):
-    from datetime import datetime, timedelta
+    from datetime import UTC, datetime, timedelta
 
     await built_state.report_error("first", RuntimeError("a"))
     # Force the cooldown to be in the past.
-    built_state._last_error_report = datetime.now() - timedelta(hours=1)
+    built_state.error_reporter.last_report = datetime.now(UTC) - timedelta(hours=1)
     await built_state.report_error("second", RuntimeError("b"))
     assert fake_guild._log.send.await_count == 2
 


### PR DESCRIPTION
## Summary

Ten findings from a focused state.py review, fixed in a single PR. No behavior change visible to Discord users; one bugfix (#1) and several internal cleanups.

### Bug fix
1. **announce_video flips order**: persist video ID *after* a successful Discord send. Previous order silently dropped announcements when send failed.

### Consistency / correctness
2. **Whitelist deduped**: `check_members_apoiadores` now reuses `parse_username_whitelist` + `ACELERADO_APOIADORES_WHITELIST` (already used by `review.py`) instead of hardcoding `\"eniaw\"`.
4. **Aware UTC everywhere in state.py**: matches `youtube.py` / `metrics.py`. Removes the silent-drift footgun the codebase already learned about with token expiry.

### Structure
3. **`AceleradoState.__init__` no longer does I/O**: first-run seeding moved to `async warm_up()`, called from the bot's `before_loop`. Fresh deployments no longer block gateway-ready on an OAuth browser flow.
5. **`LineSetStore`** (`acelerado/store.py`) replaces the two near-identical \"append-with-newline-fixup\" routines for `published.txt` and `live_reminders.txt`.
6. **`should_announce_video` / `video_state_flags` → `youtube.py`**: they're pure functions on video dicts and never used `self`.
7. **`ErrorReporter`** (`acelerado/error_reporter.py`) extracted from state. State delegates `report_error` to it.
9. **`bot._run_weekly` helper**: collapses the Monday-gate + try/except + report_error boilerplate shared by `weekly_summary_task` and `weekly_stale_task`.

### Small wins
8. `check_videos_to_pub` no longer calls `get_video_id` twice per item.
10. `metrics` gains a path-keyed in-process cache so `increment()` doesn't re-parse the JSON file on every call. Disk writes still happen, so the TUI / healthcheck see fresh data.

Plus: shared ISO-8601-with-`Z` parser (`youtube.parse_iso8601_z`) used by both `review.py` and `youtube.get_scheduled_start_time`.

## Test plan
- [x] `uv run pytest` — 187 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy acelerado` — clean
- [ ] Smoke-run the bot in a tmux session and watch the first tick land

🤖 Generated with [Claude Code](https://claude.com/claude-code)