### PR TITLE
feat(config): runtime config overlay via config.json + /config slash + acelerado config CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ published.txt
 last_tick.txt
 metrics.json
 metrics.json.tmp
+config.json
+config.json.tmp
 live_reminders.txt
 
 # Created by https://www.toptal.com/developers/gitignore/api/python

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ The codebase is small, single-bot, Python 3.11+, and is meant to run inside a `t
 - **Language:** Python >=3.11
 - **Discord:** `discord.py` 2.x — `commands.Bot` subclass (`AceleradoBot`) using `setup_hook` and `discord.ext.tasks.loop` for periodic work; `members` intent enabled
 - **YouTube:** `google-api-python-client` via OAuth2 (`google-auth-oauthlib`); a token-based client is used so members-only / unlisted videos are visible
-- **Config:** `pydantic-settings` (`BaseSettings` reading `.env`)
+- **Config:** `pydantic-settings` (`BaseSettings` in `env.py`) wrapped by a runtime `Settings` overlay in `config.py` (issue #30). Resolution: `config.json` (overlay, gitignored, atomic-written) → `.env` / process env → defaults. Edited via `acelerado config` CLI and `/config` slash group; secrets (`DISCORD_TOKEN`, `YOUTUBE_API_KEY`) are guarded — only `.env`. `get_env()` is now a thin proxy over `get_settings().cfg`; tests still call `get_env.cache_clear()` (delegates to `reload_settings()`).
 - **CLI:** `typer` — single `acelerado` entrypoint with subcommands (`run`, `audit-members`, `refresh-token`, `status`, `monitor`)
 - **TUI:** `textual` — used for the `monitor` command (live token expiry + recent announcements)
 - **Packaging:** `pyproject.toml` (hatchling), managed with `uv`
@@ -34,7 +34,9 @@ acelerado/
   state.py        # AceleradoState — per-tick orchestration + report_error
   youtube.py      # OAuth + YouTube Data API helpers (lazy lru_cache)
   tui.py          # textual MonitorApp
-  env.py          # pydantic-settings (incl. ACELERADO_TICK_SECONDS)
+  env.py          # EnvCfg pydantic schema (incl. ACELERADO_TICK_SECONDS)
+  config.py       # Settings overlay — config.json on top of EnvCfg
+                  # (atomic write, set/unset/reload, secret-key guard)
   log.py          # setup_logging() with RichHandler
 scripts/
   send_token.sh   # SCP token.pickle to a remote host

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Vai abrir o navegador. Faça login com a conta do criador (a mesma cadastrada co
 | `/preview-summary` | (admin) Posta o rascunho do resumo semanal **agora** no canal de review (botões pra Aprovar / Editar / Descartar). |
 | `/preview-stale` | (admin) Posta a lista de apoiadores stale **agora** no canal de mods. |
 | `/godbolt` | Gera link do [Compiler Explorer](https://godbolt.org) com seu código pré-carregado. Suporta C, C++, Rust, Zig, Go, Python, JavaScript, Java, Haskell, Odin. |
+| `/config list / set-channel / set / unset` | (admin) Inspeciona/edita o overlay de config runtime sem reiniciar. Picker nativo de canal — sem copiar IDs. Ver "Configuração runtime" abaixo. |
 
 Todos os slash commands são **guild-scoped** — registrados no servidor configurado em `DISCORD_GUILD_ID`, propagam instantaneamente. Para adicionar um novo, ver `acelerado/slash.py`.
 
@@ -140,6 +141,35 @@ uv run acelerado --help
 | `acelerado refresh-token`     | Faz backup de `token.pickle` e refaz o fluxo OAuth.                     |
 | `acelerado update`            | Faz `git pull --ff-only` + `uv sync --frozen`. Sai com exit 75 se atualizou; o wrapper externo deve restartar. |
 | `acelerado healthcheck [--max-age N]` | Lê `last_tick.txt` e retorna exit 0 (ok) ou 1 (stale/missing). Default `--max-age` = 2× tick interval. Útil em cron. |
+| `acelerado config list / get / set / unset / edit` | Inspeciona ou edita o overlay de configuração runtime (`config.json`). Veja "Configuração runtime" abaixo. |
+
+### Configuração runtime — `config.json` e `/config`
+
+A partir do issue #30, IDs de canal e ajustes não-secretos podem ser editados em runtime sem mexer no `.env` nem reiniciar:
+
+- **Resolução**: `config.json` (overlay) → `.env` / env vars → defaults declarados em `EnvCfg`.
+- **Segredos** (`DISCORD_TOKEN`, `YOUTUBE_API_KEY`) **continuam exclusivos do `.env`** — nunca vão pra `config.json`. Tentativas de gravá-los via CLI/slash são rejeitadas.
+- `config.json` é **gitignored** (overlay local da máquina onde o bot roda).
+
+**Pelo Discord (admin)** — picker nativo, sem copiar IDs:
+
+```
+/config list                              # mostra valores atuais + origem
+/config set-channel key:welcome channel:#boas-vindas
+/config set key:tick-seconds value:60
+/config unset key:tick-seconds
+```
+
+**Pela CLI** (útil em SSH, scripts):
+
+```sh
+uv run acelerado config list
+uv run acelerado config set DISCORD_WELCOME_CHANNEL_ID 123456789
+uv run acelerado config unset ACELERADO_TICK_SECONDS
+uv run acelerado config edit          # abre $EDITOR no config.json
+```
+
+Mudanças via `/config` ou `acelerado config set` aplicam **imediatamente** ao próximo tick / próxima slash interaction. Exceção: `ACELERADO_TICK_SECONDS` é lido uma vez em `setup_hook` — alterar exige restart.
 
 ### Logs
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ uv run acelerado --help
 | `acelerado update`            | Faz `git pull --ff-only` + `uv sync --frozen`. Sai com exit 75 se atualizou; o wrapper externo deve restartar. |
 | `acelerado healthcheck [--max-age N]` | Lê `last_tick.txt` e retorna exit 0 (ok) ou 1 (stale/missing). Default `--max-age` = 2× tick interval. Útil em cron. |
 | `acelerado config list / get / set / unset / edit` | Inspeciona ou edita o overlay de configuração runtime (`config.json`). Veja "Configuração runtime" abaixo. |
+| `acelerado channels [--all]` | Conecta no gateway, lista os canais do servidor (id + nome + categoria) e marca quais estão ligados em qual key de `config.json`. Útil pra prep de `config set` via SSH sem abrir o Discord. |
 
 ### Configuração runtime — `config.json` e `/config`
 
@@ -164,10 +165,13 @@ A partir do issue #30, IDs de canal e ajustes não-secretos podem ser editados e
 
 ```sh
 uv run acelerado config list
+uv run acelerado channels                              # lista canais do server (com IDs)
 uv run acelerado config set DISCORD_WELCOME_CHANNEL_ID 123456789
 uv run acelerado config unset ACELERADO_TICK_SECONDS
 uv run acelerado config edit          # abre $EDITOR no config.json
 ```
+
+`/config list` no Discord renderiza IDs de canal como menções clicáveis (`<#id>`) — assim você vê na hora pra que canal cada binding está apontando.
 
 Mudanças via `/config` ou `acelerado config set` aplicam **imediatamente** ao próximo tick / próxima slash interaction. Exceção: `ACELERADO_TICK_SECONDS` é lido uma vez em `setup_hook` — alterar exige restart.
 

--- a/acelerado/cli.py
+++ b/acelerado/cli.py
@@ -184,6 +184,94 @@ def healthcheck(
     console.print(f"[green]✅ ok:[/] último tick há [bold]{int(age)}s[/] (limite {max_age}s)")
 
 
+config_app = typer.Typer(
+    name="config",
+    help="Inspect and edit runtime configuration (config.json overlay).",
+    no_args_is_help=True,
+)
+app.add_typer(config_app, name="config")
+
+
+@config_app.command("list")
+def config_list() -> None:
+    """Show every config key with its effective value and origin."""
+    from acelerado.config import get_settings
+
+    settings = get_settings()
+    table = Table(title="Acelerado config")
+    table.add_column("Key")
+    table.add_column("Value")
+    table.add_column("Origin", style="dim")
+    for key in settings.all_keys():
+        table.add_row(key, settings.display_value(key), settings.origin(key))
+    console.print(table)
+
+
+@config_app.command("get")
+def config_get(key: str) -> None:
+    """Print one key's value + origin."""
+    from acelerado.config import get_settings
+    from acelerado.env import EnvCfg
+
+    if key not in EnvCfg.model_fields:
+        console.print(f"[red]Unknown key:[/] {key}")
+        raise typer.Exit(code=1)
+    settings = get_settings()
+    console.print(
+        f"[bold]{key}[/] = {settings.display_value(key)} [dim](from {settings.origin(key)})[/]"
+    )
+
+
+@config_app.command("set")
+def config_set(key: str, value: str) -> None:
+    """Persist ``key=value`` to config.json (validates type via pydantic)."""
+    from acelerado.config import get_settings
+
+    settings = get_settings()
+    try:
+        coerced = settings.set(key, value)
+    except KeyError:
+        console.print(f"[red]Unknown key:[/] {key}")
+        raise typer.Exit(code=1) from None
+    except PermissionError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1) from None
+    except ValueError as exc:
+        console.print(f"[red]Validation error:[/]\n{exc}")
+        raise typer.Exit(code=1) from None
+    console.print(f"[green]✅[/] {key} = {coerced!r} [dim](written to config.json)[/]")
+
+
+@config_app.command("unset")
+def config_unset(key: str) -> None:
+    """Remove a key from config.json (falls back to .env / default)."""
+    from acelerado.config import get_settings
+
+    settings = get_settings()
+    try:
+        settings.unset(key)
+    except KeyError:
+        console.print(f"[red]Unknown key:[/] {key}")
+        raise typer.Exit(code=1) from None
+    console.print(f"[green]✅[/] {key} unset — now reads from [bold]{settings.origin(key)}[/]")
+
+
+@config_app.command("edit")
+def config_edit() -> None:
+    """Open config.json in $EDITOR (defaults to vi); reload after exit."""
+    import os
+    import subprocess
+
+    from acelerado.config import CONFIG_PATH, reload_settings
+
+    editor = os.environ.get("EDITOR", "vi")
+    if not CONFIG_PATH.exists():
+        CONFIG_PATH.write_text("{}\n", encoding="utf-8")
+    subprocess.call([editor, str(CONFIG_PATH)])
+    reload_settings()
+    console.print(f"[green]✅[/] reloaded from {CONFIG_PATH}")
+
+
 @app.command()
 def update() -> None:
     """Pull latest commits and re-sync deps. Exit code 75 on success → wrapper restarts."""

--- a/acelerado/cli.py
+++ b/acelerado/cli.py
@@ -96,6 +96,79 @@ def audit_members() -> None:
     bot.run(get_env().DISCORD_TOKEN, log_handler=None)
 
 
+@app.command(name="channels")
+def channels(
+    text_only: Annotated[
+        bool,
+        typer.Option(
+            "--text-only/--all",
+            help="Mostra só canais de texto (default) ou todos os tipos.",
+        ),
+    ] = True,
+) -> None:
+    """List Discord channels in the configured guild — id + name + category.
+
+    Useful when prepping a `config set` from the CLI (e.g. via SSH) and you
+    don't have Discord open. Connects to the gateway, dumps the table, and
+    closes — no long-running bot.
+    """
+    import discord
+    from discord.ext import commands
+
+    from acelerado.config import CHANNEL_KEYS, get_settings
+    from acelerado.env import get_env
+
+    settings = get_settings()
+    bound: dict[int, list[str]] = {}
+    for key in CHANNEL_KEYS:
+        value = getattr(settings.cfg, key)
+        if value:
+            bound.setdefault(value, []).append(key)
+
+    intents = discord.Intents.default()
+    bot = commands.Bot(command_prefix="/", intents=intents)
+
+    @bot.event
+    async def on_ready() -> None:
+        try:
+            guild = bot.get_guild(get_env().DISCORD_GUILD_ID)
+            if guild is None:
+                logger.error("Guild not found. Check DISCORD_GUILD_ID.")
+                return
+
+            table = Table(title=f"Canais em '{guild.name}'")
+            table.add_column("Tipo")
+            table.add_column("Nome")
+            table.add_column("ID", style="dim")
+            table.add_column("Categoria", style="dim")
+            table.add_column("Bound to", style="cyan")
+
+            channels_iter = sorted(
+                guild.channels,
+                key=lambda c: (
+                    (c.category.position if c.category else -1),
+                    getattr(c, "position", 0),
+                ),
+            )
+            for chan in channels_iter:
+                if text_only and not isinstance(chan, discord.TextChannel):
+                    continue
+                bound_keys = ", ".join(bound.get(chan.id, [])) or "—"
+                category = chan.category.name if chan.category else "—"
+                table.add_row(
+                    type(chan).__name__.removesuffix("Channel").lower(),
+                    chan.name,
+                    str(chan.id),
+                    category,
+                    bound_keys,
+                )
+            console.print(table)
+        finally:
+            await bot.close()
+
+    bot.run(get_env().DISCORD_TOKEN, log_handler=None)
+
+
 @app.command(name="refresh-token")
 def refresh_token() -> None:
     """Force a fresh YouTube OAuth flow (backs up the existing token)."""

--- a/acelerado/config.py
+++ b/acelerado/config.py
@@ -1,0 +1,246 @@
+"""Layered runtime settings: ``config.json`` overrides ``.env`` overrides defaults.
+
+The motivation (issue #30): IDs of channels/guild are *configuration*, not
+secrets. Editing ``.env`` + restarting just to repoint the welcome channel
+is friction we don't want. Secrets stay in ``.env`` (read by ``EnvCfg``);
+runtime config moves to ``config.json``, editable via CLI (``acelerado
+config``) and Discord slash commands (``/config``).
+
+Resolution order (highest priority first):
+
+1. ``config.json`` (atomic-written by :meth:`Settings.set`).
+2. ``.env`` / process env (handled by ``EnvCfg`` via pydantic-settings).
+3. Defaults declared on ``EnvCfg``.
+
+Secrets — ``DISCORD_TOKEN``, ``YOUTUBE_API_KEY`` — are never written to
+``config.json``. :meth:`Settings.set` rejects them; loader silently drops
+them if they appear in the file (defense in depth).
+
+Threading: the bot is single-threaded async; we don't lock. Atomic
+``.tmp`` + replace keeps external readers (TUI, healthcheck) from seeing
+half-written files, mirroring ``metrics.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from acelerado.env import EnvCfg
+
+logger = logging.getLogger(__name__)
+
+CONFIG_PATH = Path("config.json")
+ENV_FILE_PATH = Path(".env")
+
+# Keys that MUST stay in environment / .env. Writing these to config.json
+# would leak secrets into a file that's easy to accidentally commit.
+SECRET_KEYS: frozenset[str] = frozenset({"DISCORD_TOKEN", "YOUTUBE_API_KEY"})
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_env_file_keys(path: Path = ENV_FILE_PATH) -> set[str]:
+    """Names defined in ``.env`` (best-effort parser, no quotes/expansion)."""
+    if not path.exists():
+        return set()
+    keys: set[str] = set()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        name, _ = line.split("=", 1)
+        keys.add(name.strip())
+    return keys
+
+
+class Settings:
+    """Merged view of layered configuration.
+
+    Construct once via :func:`get_settings`; mutating methods (:meth:`set`,
+    :meth:`unset`) update the in-memory ``cfg`` *and* persist to disk so
+    the next access — including from other modules holding a fresh
+    ``get_settings()`` reference — sees the change immediately.
+    """
+
+    def __init__(self, path: Path = CONFIG_PATH) -> None:
+        self.path = path
+        self._overrides: dict[str, Any] = {}
+        self._cfg: EnvCfg
+        self._load_overrides()
+        self._build_cfg()
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    def _load_overrides(self) -> None:
+        if not self.path.exists():
+            self._overrides = {}
+            return
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(f"{self.path} unreadable ({exc}); ignoring overrides")
+            self._overrides = {}
+            return
+        if not isinstance(data, dict):
+            logger.warning(f"{self.path} must be a JSON object; ignoring overrides")
+            self._overrides = {}
+            return
+
+        valid: dict[str, Any] = {}
+        for key, value in data.items():
+            if key not in EnvCfg.model_fields:
+                logger.warning(f"Ignoring unknown {self.path.name} key: {key}")
+                continue
+            if key in SECRET_KEYS:
+                logger.warning(f"Ignoring secret key {key} in {self.path.name}")
+                continue
+            valid[key] = value
+        self._overrides = valid
+
+    def _build_cfg(self) -> None:
+        base = EnvCfg()
+        if not self._overrides:
+            self._cfg = base
+            return
+        data = base.model_dump()
+        data.update(self._overrides)
+        try:
+            self._cfg = EnvCfg.model_validate(data)
+        except ValidationError as exc:
+            logger.warning(f"config.json overrides invalid ({exc}); ignoring")
+            self._cfg = base
+
+    # ------------------------------------------------------------------
+    # Public read API
+    # ------------------------------------------------------------------
+
+    @property
+    def cfg(self) -> EnvCfg:
+        return self._cfg
+
+    def reload(self) -> None:
+        self._load_overrides()
+        self._build_cfg()
+
+    def all_keys(self) -> list[str]:
+        return list(EnvCfg.model_fields.keys())
+
+    def origin(self, key: str) -> str:
+        """Return where ``key``'s effective value came from.
+
+        One of: ``"config.json"``, ``"env"``, ``".env"``, ``"default"``.
+        Raises ``KeyError`` for unknown keys.
+        """
+        if key not in EnvCfg.model_fields:
+            raise KeyError(key)
+        if key in self._overrides:
+            return "config.json"
+        if os.environ.get(key) is not None:
+            return "env"
+        if key in _read_env_file_keys(ENV_FILE_PATH):
+            return ".env"
+        return "default"
+
+    def display_value(self, key: str) -> str:
+        """Render ``key``'s value for human display, redacting secrets."""
+        if key not in EnvCfg.model_fields:
+            raise KeyError(key)
+        value = getattr(self._cfg, key)
+        if key in SECRET_KEYS:
+            if isinstance(value, str) and len(value) >= 4:
+                return f"***{value[-4:]}"
+            return "***"
+        return repr(value)
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def set(self, key: str, raw_value: Any) -> Any:
+        """Persist ``key=raw_value`` to ``config.json`` after type-validation.
+
+        Returns the typed/coerced value pydantic produced. Raises:
+
+        - :class:`KeyError` for unknown keys,
+        - :class:`PermissionError` for secret keys,
+        - :class:`ValueError` on validation failure (wraps ``ValidationError``).
+        """
+        if key not in EnvCfg.model_fields:
+            raise KeyError(f"Unknown config key: {key}")
+        if key in SECRET_KEYS:
+            raise PermissionError(f"{key} is a secret — set it in .env, not config.json")
+
+        data = self._cfg.model_dump()
+        data[key] = raw_value
+        try:
+            validated = EnvCfg.model_validate(data)
+        except ValidationError as exc:
+            raise ValueError(str(exc)) from exc
+
+        coerced = getattr(validated, key)
+        self._overrides[key] = coerced
+        _atomic_write_json(self.path, self._overrides)
+        self._cfg = validated
+        return coerced
+
+    def unset(self, key: str) -> None:
+        """Remove ``key`` from ``config.json``; falls back to env / default.
+
+        Raises :class:`KeyError` for unknown keys. No-op if the key has no
+        override.
+        """
+        if key not in EnvCfg.model_fields:
+            raise KeyError(key)
+        if key not in self._overrides:
+            return
+        del self._overrides[key]
+        if self._overrides:
+            _atomic_write_json(self.path, self._overrides)
+        else:
+            try:
+                self.path.unlink()
+            except FileNotFoundError:
+                pass
+        self._build_cfg()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_singleton: Settings | None = None
+
+
+def get_settings() -> Settings:
+    global _singleton
+    if _singleton is None:
+        _singleton = Settings()
+    return _singleton
+
+
+def reload_settings() -> None:
+    """Drop the singleton so the next ``get_settings()`` re-reads everything.
+
+    Used by the CLI's ``config edit`` (after $EDITOR exits) and by the
+    test fixtures so per-test env-var monkeypatching takes effect.
+    """
+    global _singleton
+    _singleton = None

--- a/acelerado/config.py
+++ b/acelerado/config.py
@@ -42,6 +42,19 @@ ENV_FILE_PATH = Path(".env")
 # would leak secrets into a file that's easy to accidentally commit.
 SECRET_KEYS: frozenset[str] = frozenset({"DISCORD_TOKEN", "YOUTUBE_API_KEY"})
 
+# Keys whose value is a Discord channel ID. Used by renderers (slash,
+# CLI) to format the value as ``<#id>`` (clickable mention) instead of a
+# bare int. Update this set when a new channel-shaped key is added.
+CHANNEL_KEYS: frozenset[str] = frozenset(
+    {
+        "DISCORD_ANNOUNCE_CHANNEL_ID",
+        "DISCORD_LOG_CHANNEL_ID",
+        "DISCORD_WELCOME_CHANNEL_ID",
+        "DISCORD_MODS_CHANNEL_ID",
+        "DISCORD_REVIEW_CHANNEL_ID",
+    }
+)
+
 
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
     tmp = path.with_suffix(path.suffix + ".tmp")

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -1,4 +1,12 @@
-from functools import lru_cache
+"""Schema for all bot configuration.
+
+``EnvCfg`` is the single pydantic-settings model — it reads ``.env`` /
+process env. The runtime layering (``config.json`` overrides on top of
+this) lives in :mod:`acelerado.config`. Most callers should keep using
+:func:`get_env`, which proxies through to the merged ``Settings.cfg``.
+"""
+
+from __future__ import annotations
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -42,6 +50,31 @@ class EnvCfg(BaseSettings):
     ACELERADO_APOIADORES_WHITELIST: str = "eniaw"
 
 
-@lru_cache(maxsize=1)
 def get_env() -> EnvCfg:
-    return EnvCfg()
+    """Return the merged :class:`EnvCfg`, with ``config.json`` applied on top.
+
+    Thin wrapper over :func:`acelerado.config.get_settings` kept for
+    backward compatibility — every call site does ``get_env().FOO`` and
+    we don't want to thrash that whole graph just to add a new layer.
+    """
+    from acelerado.config import get_settings
+
+    return get_settings().cfg
+
+
+def _cache_clear() -> None:
+    """Compatibility shim for tests that used to call ``get_env.cache_clear()``.
+
+    Delegates to :func:`acelerado.config.reload_settings` so monkeypatched
+    env vars or freshly-written ``config.json`` files take effect on the
+    next access.
+    """
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+
+# Tests call ``env_mod.get_env.cache_clear()`` to reset state between cases.
+# Preserve that surface by attaching a callable attribute to the function
+# (mirrors the ``functools.lru_cache`` API the previous version exposed).
+get_env.cache_clear = _cache_clear  # type: ignore[attr-defined]

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -283,15 +283,24 @@ def _build_config_group() -> app_commands.Group:
 
     @group.command(name="list", description="Mostra config atual + origem")
     async def cmd_config_list(interaction: discord.Interaction) -> None:
+        from acelerado.config import CHANNEL_KEYS
+
         settings = get_settings()
         embed = discord.Embed(
             title="⚙️ Config atual",
             color=discord.Color.blurple(),
         )
         for key in settings.all_keys():
+            # Channel-typed keys: render as <#id> so the ID resolves to a
+            # clickable mention; bare ints aren't actionable.
+            if key in CHANNEL_KEYS:
+                cid = getattr(settings.cfg, key)
+                rendered = f"<#{cid}>" if cid else "*(não configurado)*"
+            else:
+                rendered = f"`{settings.display_value(key)}`"
             embed.add_field(
                 name=key,
-                value=f"`{settings.display_value(key)}` *(de {settings.origin(key)})*",
+                value=f"{rendered} *(de {settings.origin(key)})*",
                 inline=False,
             )
         await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -241,6 +241,128 @@ async def cmd_report(
     await interaction.followup.send(result_msg, ephemeral=True)
 
 
+# ---------------------------------------------------------------------------
+# /config — runtime configuration overlay (issue #30)
+# ---------------------------------------------------------------------------
+#
+# Built as an ``app_commands.Group`` so the surface is ``/config list``,
+# ``/config set-channel``, etc., instead of ``cmd_config_list`` style. The
+# group instance must be re-created per registration call (discord.py
+# binds it to a tree at add time and barfs on re-registration), so it
+# lives inside :func:`_build_config_group` rather than at module scope.
+
+_CHANNEL_KEY_CHOICES = [
+    app_commands.Choice(name="announce", value="DISCORD_ANNOUNCE_CHANNEL_ID"),
+    app_commands.Choice(name="log", value="DISCORD_LOG_CHANNEL_ID"),
+    app_commands.Choice(name="welcome", value="DISCORD_WELCOME_CHANNEL_ID"),
+    app_commands.Choice(name="mods", value="DISCORD_MODS_CHANNEL_ID"),
+    app_commands.Choice(name="review", value="DISCORD_REVIEW_CHANNEL_ID"),
+]
+
+# Non-channel, non-secret editable keys exposed via /config set + unset.
+_PLAIN_KEY_CHOICES = [
+    app_commands.Choice(name="tick-seconds", value="ACELERADO_TICK_SECONDS"),
+    app_commands.Choice(name="auto-thread", value="ACELERADO_AUTO_THREAD"),
+    app_commands.Choice(name="live-reminder-min", value="ACELERADO_LIVE_REMINDER_MINUTES"),
+    app_commands.Choice(name="apoiadores-whitelist", value="ACELERADO_APOIADORES_WHITELIST"),
+]
+
+# Union for /config unset (covers every editable key).
+_UNSET_KEY_CHOICES = _CHANNEL_KEY_CHOICES + _PLAIN_KEY_CHOICES
+
+
+def _build_config_group() -> app_commands.Group:
+    """Build a fresh ``/config`` group bound to a single tree."""
+    from acelerado.config import get_settings
+
+    group = app_commands.Group(
+        name="config",
+        description="Inspecionar/editar config runtime do bot",
+        default_permissions=discord.Permissions(administrator=True),
+    )
+
+    @group.command(name="list", description="Mostra config atual + origem")
+    async def cmd_config_list(interaction: discord.Interaction) -> None:
+        settings = get_settings()
+        embed = discord.Embed(
+            title="⚙️ Config atual",
+            color=discord.Color.blurple(),
+        )
+        for key in settings.all_keys():
+            embed.add_field(
+                name=key,
+                value=f"`{settings.display_value(key)}` *(de {settings.origin(key)})*",
+                inline=False,
+            )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @group.command(
+        name="set-channel",
+        description="Aponta uma config-canal pro canal escolhido (resolve ID automaticamente)",
+    )
+    @app_commands.describe(key="Qual canal configurar", channel="Canal alvo")
+    @app_commands.choices(key=_CHANNEL_KEY_CHOICES)
+    async def cmd_config_set_channel(
+        interaction: discord.Interaction,
+        key: app_commands.Choice[str],
+        channel: discord.TextChannel,
+    ) -> None:
+        try:
+            get_settings().set(key.value, channel.id)
+        except (KeyError, PermissionError, ValueError) as exc:
+            await interaction.response.send_message(f"⚠️ {exc}", ephemeral=True)
+            return
+        await interaction.response.send_message(
+            f"✅ `{key.value}` = <#{channel.id}>", ephemeral=True
+        )
+
+    @group.command(
+        name="set",
+        description="Define uma config não-canal (int, bool, string)",
+    )
+    @app_commands.describe(key="Qual config", value="Valor (será coerced via pydantic)")
+    @app_commands.choices(key=_PLAIN_KEY_CHOICES)
+    async def cmd_config_set(
+        interaction: discord.Interaction,
+        key: app_commands.Choice[str],
+        value: str,
+    ) -> None:
+        try:
+            coerced = get_settings().set(key.value, value)
+        except (KeyError, PermissionError) as exc:
+            await interaction.response.send_message(f"⚠️ {exc}", ephemeral=True)
+            return
+        except ValueError as exc:
+            await interaction.response.send_message(
+                f"⚠️ Valor inválido para `{key.value}`:\n```\n{str(exc)[:500]}\n```",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(f"✅ `{key.value}` = `{coerced!r}`", ephemeral=True)
+
+    @group.command(
+        name="unset",
+        description="Remove um override (volta pro fallback .env / default)",
+    )
+    @app_commands.choices(key=_UNSET_KEY_CHOICES)
+    async def cmd_config_unset(
+        interaction: discord.Interaction,
+        key: app_commands.Choice[str],
+    ) -> None:
+        settings = get_settings()
+        try:
+            settings.unset(key.value)
+        except KeyError as exc:
+            await interaction.response.send_message(f"⚠️ {exc}", ephemeral=True)
+            return
+        await interaction.response.send_message(
+            f"✅ `{key.value}` removido — agora vem de `{settings.origin(key.value)}`",
+            ephemeral=True,
+        )
+
+    return group
+
+
 def register_commands(
     tree: app_commands.CommandTree,
     guild: discord.abc.Snowflake | None = None,
@@ -259,3 +381,4 @@ def register_commands(
     tree.add_command(cmd_preview_summary, guild=guild)
     tree.add_command(cmd_preview_stale, guild=guild)
     tree.add_command(cmd_godbolt, guild=guild)
+    tree.add_command(_build_config_group(), guild=guild)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,11 @@ def chdir_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 @pytest.fixture(autouse=True)
 def clear_caches() -> None:
     """Reset lru_cache-backed singletons so tests don't leak state."""
-    from acelerado import env as env_mod
+    from acelerado import config as config_mod
     from acelerado import metrics as metrics_mod
     from acelerado import youtube as yt_mod
 
-    env_mod.get_env.cache_clear()
+    config_mod.reload_settings()
     yt_mod._youtube.cache_clear()
     yt_mod.get_upload_playlist_id.cache_clear()
     metrics_mod.reset_cache()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,3 +153,69 @@ def test_healthcheck_corrupted_file_exits_one(chdir_tmp):
     result = runner.invoke(app, ["healthcheck"])
     assert result.exit_code == 1
     assert "corromp" in result.stdout.lower() or "stale" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# acelerado config
+# ---------------------------------------------------------------------------
+
+
+def test_config_list_shows_keys_and_origins(chdir_tmp):
+    result = runner.invoke(app, ["config", "list"])
+    assert result.exit_code == 0
+    assert "ACELERADO_TICK_SECONDS" in result.stdout
+    assert "DISCORD_TOKEN" in result.stdout
+
+
+def test_config_list_redacts_secrets(chdir_tmp):
+    result = runner.invoke(app, ["config", "list"])
+    assert "test-discord-token" not in result.stdout
+
+
+def test_config_get_known_key(chdir_tmp):
+    result = runner.invoke(app, ["config", "get", "ACELERADO_TICK_SECONDS"])
+    assert result.exit_code == 0
+    assert "300" in result.stdout
+
+
+def test_config_get_unknown_key_exits_one(chdir_tmp):
+    result = runner.invoke(app, ["config", "get", "NOT_A_KEY"])
+    assert result.exit_code == 1
+    assert "unknown" in result.stdout.lower()
+
+
+def test_config_set_persists_and_get_reflects_it(chdir_tmp):
+    set_result = runner.invoke(app, ["config", "set", "ACELERADO_TICK_SECONDS", "120"])
+    assert set_result.exit_code == 0, set_result.stdout
+    assert "config.json" in set_result.stdout
+
+    get_result = runner.invoke(app, ["config", "get", "ACELERADO_TICK_SECONDS"])
+    assert get_result.exit_code == 0
+    assert "120" in get_result.stdout
+    assert "config.json" in get_result.stdout
+
+
+def test_config_set_invalid_value_exits_one(chdir_tmp):
+    result = runner.invoke(app, ["config", "set", "ACELERADO_TICK_SECONDS", "not-int"])
+    assert result.exit_code == 1
+    assert "validation" in result.stdout.lower()
+
+
+def test_config_set_secret_blocked(chdir_tmp):
+    result = runner.invoke(app, ["config", "set", "DISCORD_TOKEN", "leak"])
+    assert result.exit_code == 1
+    assert "secret" in result.stdout.lower()
+
+
+def test_config_unset_returns_to_fallback(chdir_tmp):
+    runner.invoke(app, ["config", "set", "ACELERADO_TICK_SECONDS", "120"])
+    unset_result = runner.invoke(app, ["config", "unset", "ACELERADO_TICK_SECONDS"])
+    assert unset_result.exit_code == 0
+    get_result = runner.invoke(app, ["config", "get", "ACELERADO_TICK_SECONDS"])
+    # Reverts to env (test fixture doesn't set it -> default 300)
+    assert "300" in get_result.stdout
+
+
+def test_config_unset_unknown_key_exits_one(chdir_tmp):
+    result = runner.invoke(app, ["config", "unset", "NOT_A_KEY"])
+    assert result.exit_code == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,192 @@
+"""Tests for ``acelerado.config`` — layered Settings + persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from acelerado import config as config_mod
+from acelerado.config import CONFIG_PATH, SECRET_KEYS, Settings
+
+
+def test_defaults_when_no_config_json() -> None:
+    s = Settings()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 300
+    assert s.cfg.ACELERADO_AUTO_THREAD is True
+    assert s.origin("ACELERADO_TICK_SECONDS") == "default"
+
+
+def test_env_var_takes_precedence_over_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACELERADO_TICK_SECONDS", "42")
+    s = Settings()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 42
+    assert s.origin("ACELERADO_TICK_SECONDS") == "env"
+
+
+def test_config_json_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACELERADO_TICK_SECONDS", "42")
+    CONFIG_PATH.write_text(json.dumps({"ACELERADO_TICK_SECONDS": 99}), encoding="utf-8")
+    s = Settings()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 99
+    assert s.origin("ACELERADO_TICK_SECONDS") == "config.json"
+
+
+def test_set_persists_and_returns_coerced() -> None:
+    s = Settings()
+    coerced = s.set("ACELERADO_TICK_SECONDS", "120")
+    assert coerced == 120  # str coerced to int via pydantic
+    assert s.cfg.ACELERADO_TICK_SECONDS == 120
+    on_disk = json.loads(CONFIG_PATH.read_text())
+    assert on_disk == {"ACELERADO_TICK_SECONDS": 120}
+
+
+def test_set_invalid_value_raises_valueerror() -> None:
+    s = Settings()
+    with pytest.raises(ValueError):
+        s.set("ACELERADO_TICK_SECONDS", "not-an-int")
+    # cfg unchanged, no file written
+    assert s.cfg.ACELERADO_TICK_SECONDS == 300
+    assert not CONFIG_PATH.exists()
+
+
+def test_set_unknown_key_raises_keyerror() -> None:
+    s = Settings()
+    with pytest.raises(KeyError):
+        s.set("NOT_A_REAL_KEY", "x")
+
+
+def test_set_secret_raises_permissionerror() -> None:
+    s = Settings()
+    for secret in SECRET_KEYS:
+        with pytest.raises(PermissionError):
+            s.set(secret, "leaked")
+    assert not CONFIG_PATH.exists()
+
+
+def test_unset_removes_from_disk_and_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACELERADO_TICK_SECONDS", "42")
+    s = Settings()
+    s.set("ACELERADO_TICK_SECONDS", 99)
+    assert s.cfg.ACELERADO_TICK_SECONDS == 99
+    s.unset("ACELERADO_TICK_SECONDS")
+    assert s.cfg.ACELERADO_TICK_SECONDS == 42
+    assert not CONFIG_PATH.exists()  # last override removed -> file deleted
+    assert s.origin("ACELERADO_TICK_SECONDS") == "env"
+
+
+def test_unset_missing_key_is_noop() -> None:
+    s = Settings()
+    s.unset("ACELERADO_TICK_SECONDS")  # no error, no file
+    assert not CONFIG_PATH.exists()
+
+
+def test_unset_unknown_key_raises_keyerror() -> None:
+    s = Settings()
+    with pytest.raises(KeyError):
+        s.unset("NOT_A_REAL_KEY")
+
+
+def test_corrupted_config_json_is_ignored(caplog: pytest.LogCaptureFixture) -> None:
+    CONFIG_PATH.write_text("{not valid json", encoding="utf-8")
+    s = Settings()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 300  # default
+    assert "unreadable" in caplog.text.lower() or "invalid" in caplog.text.lower()
+
+
+def test_secret_key_in_config_json_is_dropped(caplog: pytest.LogCaptureFixture) -> None:
+    CONFIG_PATH.write_text(
+        json.dumps({"DISCORD_TOKEN": "leaked", "ACELERADO_TICK_SECONDS": 60}),
+        encoding="utf-8",
+    )
+    s = Settings()
+    # Token still comes from env, not from config.json
+    assert s.cfg.DISCORD_TOKEN == "test-discord-token"
+    assert s.cfg.ACELERADO_TICK_SECONDS == 60
+    assert "secret" in caplog.text.lower()
+
+
+def test_unknown_key_in_config_json_is_dropped(caplog: pytest.LogCaptureFixture) -> None:
+    CONFIG_PATH.write_text(
+        json.dumps({"FROM_FUTURE_VERSION": "x", "ACELERADO_TICK_SECONDS": 77}),
+        encoding="utf-8",
+    )
+    s = Settings()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 77
+    assert "unknown" in caplog.text.lower()
+
+
+def test_atomic_write_no_tmp_left_behind() -> None:
+    s = Settings()
+    s.set("ACELERADO_TICK_SECONDS", 60)
+    assert CONFIG_PATH.exists()
+    assert not Path("config.json.tmp").exists()
+
+
+def test_reload_picks_up_external_edit(monkeypatch: pytest.MonkeyPatch) -> None:
+    s = Settings()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 300
+    CONFIG_PATH.write_text(json.dumps({"ACELERADO_TICK_SECONDS": 12}), encoding="utf-8")
+    s.reload()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 12
+
+
+def test_singleton_get_settings_returns_same_instance() -> None:
+    a = config_mod.get_settings()
+    b = config_mod.get_settings()
+    assert a is b
+
+
+def test_reload_settings_drops_singleton() -> None:
+    a = config_mod.get_settings()
+    config_mod.reload_settings()
+    b = config_mod.get_settings()
+    assert a is not b
+
+
+def test_display_value_redacts_secrets() -> None:
+    s = Settings()
+    rendered = s.display_value("DISCORD_TOKEN")
+    assert "test-discord-token" not in rendered
+    assert rendered.startswith("***")
+
+
+def test_display_value_for_non_secret_is_repr() -> None:
+    s = Settings()
+    assert s.display_value("ACELERADO_TICK_SECONDS") == "300"
+
+
+def test_origin_distinguishes_env_file_vs_process_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key only in .env (not process env) reports origin=='.env'."""
+    # Drop the test-fixture process-env override for one var, then write
+    # it into a .env file that EnvCfg will pick up.
+    monkeypatch.delenv("ACELERADO_TICK_SECONDS", raising=False)
+    Path(".env").write_text(
+        # Required vars + the one we care about.
+        "DISCORD_TOKEN=test-discord-token\n"
+        "DISCORD_GUILD_ID=111\n"
+        "DISCORD_ANNOUNCE_CHANNEL_ID=222\n"
+        "DISCORD_LOG_CHANNEL_ID=333\n"
+        "YOUTUBE_CHANNEL_ID=UC_test_channel\n"
+        "YOUTUBE_API_KEY=test-api-key\n"
+        "ACELERADO_TICK_SECONDS=77\n",
+        encoding="utf-8",
+    )
+    # Required vars must NOT be in process env or pydantic-settings will
+    # report "env" instead of ".env"; clear them.
+    for k in (
+        "DISCORD_TOKEN",
+        "DISCORD_GUILD_ID",
+        "DISCORD_ANNOUNCE_CHANNEL_ID",
+        "DISCORD_LOG_CHANNEL_ID",
+        "YOUTUBE_CHANNEL_ID",
+        "YOUTUBE_API_KEY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    s = Settings()
+    assert s.cfg.ACELERADO_TICK_SECONDS == 77
+    assert s.origin("ACELERADO_TICK_SECONDS") == ".env"

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -285,6 +285,103 @@ async def test_report_invalid_link_responds_with_warning():
     assert "inválido" in msg.lower()
 
 
+# ---------------------------------------------------------------------------
+# /config group
+# ---------------------------------------------------------------------------
+
+
+def test_register_config_group():
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    cmd = tree.get_command("config", guild=guild)
+    assert cmd is not None
+    assert isinstance(cmd, app_commands.Group)
+    sub_names = {c.name for c in cmd.commands}
+    assert sub_names == {"list", "set-channel", "set", "unset"}
+
+
+def _get_config_subcommand(name: str):
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    group = tree.get_command("config", guild=guild)
+    assert isinstance(group, app_commands.Group)
+    for cmd in group.commands:
+        if cmd.name == name:
+            return cmd
+    raise AssertionError(f"subcommand {name!r} not registered")
+
+
+def _make_admin_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+async def test_config_list_renders_embed(chdir_tmp):
+    cmd = _get_config_subcommand("list")
+    interaction = _make_admin_interaction()
+    await cmd.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    embed = interaction.response.send_message.await_args.kwargs.get("embed")
+    assert isinstance(embed, discord.Embed)
+    field_names = {f.name for f in embed.fields}
+    assert "ACELERADO_TICK_SECONDS" in field_names
+    # Secret redaction
+    rendered = " ".join(f.value or "" for f in embed.fields)
+    assert "test-discord-token" not in rendered
+
+
+async def test_config_set_channel_persists_id(chdir_tmp):
+    from acelerado.config import get_settings, reload_settings
+
+    reload_settings()
+    cmd = _get_config_subcommand("set-channel")
+    interaction = _make_admin_interaction()
+
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 555_666_777
+    choice = app_commands.Choice(name="welcome", value="DISCORD_WELCOME_CHANNEL_ID")
+
+    await cmd.callback(interaction, key=choice, channel=channel)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "555666777" in msg.replace(",", "")
+    # Persisted to Settings
+    assert get_settings().cfg.DISCORD_WELCOME_CHANNEL_ID == 555_666_777
+
+
+async def test_config_set_invalid_value_responds_with_warning(chdir_tmp):
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_config_subcommand("set")
+    interaction = _make_admin_interaction()
+
+    choice = app_commands.Choice(name="tick-seconds", value="ACELERADO_TICK_SECONDS")
+    await cmd.callback(interaction, key=choice, value="not-an-int")
+
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "inválido" in msg.lower()
+
+
+async def test_config_unset_reverts_to_fallback(chdir_tmp):
+    from acelerado.config import get_settings, reload_settings
+
+    reload_settings()
+    get_settings().set("ACELERADO_TICK_SECONDS", 99)
+    cmd = _get_config_subcommand("unset")
+    interaction = _make_admin_interaction()
+    choice = app_commands.Choice(name="tick-seconds", value="ACELERADO_TICK_SECONDS")
+
+    await cmd.callback(interaction, key=choice)
+    interaction.response.send_message.assert_awaited_once()
+    assert get_settings().cfg.ACELERADO_TICK_SECONDS == 300  # back to default
+
+
 async def test_update_command_ok_schedules_restart(monkeypatch):
     import asyncio
 

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -334,6 +334,31 @@ async def test_config_list_renders_embed(chdir_tmp):
     assert "test-discord-token" not in rendered
 
 
+async def test_config_list_renders_channel_keys_as_mentions(chdir_tmp):
+    """Channel-typed keys must render as <#id> so they're clickable."""
+    cmd = _get_config_subcommand("list")
+    interaction = _make_admin_interaction()
+    await cmd.callback(interaction)
+    embed = interaction.response.send_message.await_args.kwargs.get("embed")
+    fields = {f.name: (f.value or "") for f in embed.fields}
+    # Test fixture sets DISCORD_ANNOUNCE_CHANNEL_ID=222 — should render <#222>.
+    assert "<#222>" in fields["DISCORD_ANNOUNCE_CHANNEL_ID"]
+    assert "<#333>" in fields["DISCORD_LOG_CHANNEL_ID"]
+
+
+async def test_config_list_marks_unset_channels(chdir_tmp):
+    """Channel keys defaulting to 0 should show 'não configurado', not <#0>."""
+    cmd = _get_config_subcommand("list")
+    interaction = _make_admin_interaction()
+    await cmd.callback(interaction)
+    embed = interaction.response.send_message.await_args.kwargs.get("embed")
+    fields = {f.name: (f.value or "") for f in embed.fields}
+    # DISCORD_WELCOME_CHANNEL_ID has no fixture override -> defaults to 0.
+    welcome = fields["DISCORD_WELCOME_CHANNEL_ID"]
+    assert "<#0>" not in welcome
+    assert "não configurado" in welcome
+
+
 async def test_config_set_channel_persists_id(chdir_tmp):
     from acelerado.config import get_settings, reload_settings
 


### PR DESCRIPTION
Closes #30.

## Summary

- New `acelerado/config.py` — `Settings` overlay reading `config.json` on top of `EnvCfg`. Resolution order: `config.json` → `.env` / process env → defaults declared on `EnvCfg`. Atomic-written (`.tmp` + replace, mirroring `metrics.py`).
- **Secret guard**: `DISCORD_TOKEN` and `YOUTUBE_API_KEY` are rejected by `.set()` and silently dropped on load — they remain `.env`-only.
- `acelerado config list / get / set / unset / edit` CLI subcommands.
- `/config` slash group (admin-gated, ephemeral): `list`, `set-channel` (uses native `discord.TextChannel` picker — no copy/paste of IDs), `set`, `unset`. Mudanças aplicam **imediatamente** no próximo tick / próxima interaction.
- `get_env()` is now a thin proxy over `get_settings().cfg`, with a `cache_clear` shim that delegates to `reload_settings()` so existing tests and call sites work unchanged.
- `config.json` + `config.json.tmp` added to `.gitignore`.
- Docs: README has a new "Configuração runtime" section + CLI/slash table rows; CLAUDE.md updated.

## Out of scope (per issue)

- Hot-reload of `tasks.loop` interval — `ACELERADO_TICK_SECONDS` is read once in `setup_hook`; changing it still requires a restart.
- Auto-import from `.env` on first run — the layering already handles backward compat (`.env` keeps working as the lower layer).

## Test plan

- [x] `uv run pytest` — **221 passed** (20 new in `tests/test_config.py`, 9 in `tests/test_cli.py`, 5 in `tests/test_slash.py`).
- [x] `uv run ruff check acelerado tests` — clean.
- [x] `uv run ruff format --check acelerado tests` — clean.
- [x] `uv run mypy acelerado` — clean.
- [x] `uv run acelerado config --help` smoke-tested locally.
- [ ] Smoke `/config set-channel` against the live guild after merge (cannot exercise the gateway from CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)