### PR TITLE
feat(antispam): cross-channel detector with alert/delete/timeout actions

### DIFF
--- a/acelerado/antispam.py
+++ b/acelerado/antispam.py
@@ -1,0 +1,333 @@
+"""Cross-channel anti-spam (issue #31).
+
+Spam bots typically post the same payload across several channels in a
+few seconds before they're banned. This module tracks a per-user sliding
+window of ``(channel_id, content_hash, timestamp)`` and reacts when a
+user posts in N distinct channels (or repeats the same content across
+channels) inside the window.
+
+Layout follows ``moderation.py``:
+
+- :func:`detect_cross_channel_spam` — pure, easy to unit-test.
+- :func:`handle_message_for_spam` — async coroutine called from the
+  bot's ``on_message`` listener.
+- A small in-memory ``defaultdict[user_id, deque]`` tracks recent
+  history; a separate dict tracks per-user alert cooldowns. Restart
+  resets both — that's an acceptable tradeoff for v1.
+
+The whole thing is opt-in via ``ACELERADO_ANTISPAM_ENABLED``; defaults
+chosen so an admin can flip it on, watch alerts in the mods channel,
+and only escalate to ``delete``/``timeout`` once they've confirmed zero
+false positives on their server.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import logging
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+
+import discord
+from discord.ext import commands
+
+from acelerado.env import get_env
+
+logger = logging.getLogger(__name__)
+
+# How many entries we keep per user. Bigger than any reasonable window
+# at the configured threshold, so pruning by timestamp is the real
+# bound. Cap protects memory if a user is exceptionally chatty.
+_MAX_HISTORY_PER_USER = 50
+
+
+@dataclass(frozen=True)
+class HistoryEntry:
+    channel_id: int
+    content_hash: str
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class SpamSignal:
+    user_id: int
+    distinct_channels: int
+    repeated_content: bool
+    window_seconds: float
+    channel_ids: tuple[int, ...]
+
+
+_history: dict[int, deque[HistoryEntry]] = defaultdict(lambda: deque(maxlen=_MAX_HISTORY_PER_USER))
+_alert_last_sent: dict[int, float] = {}
+
+
+def reset_caches() -> None:
+    """Test helper — clear in-memory tracking between tests."""
+    _history.clear()
+    _alert_last_sent.clear()
+
+
+def _hash_content(content: str) -> str:
+    # Normalize whitespace + case so trivial variants of the same paste
+    # collide. Hash kept short — collisions don't matter, equality does.
+    normalized = " ".join(content.lower().split())
+    return hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_channel_whitelist(raw: str) -> set[int]:
+    out: set[int] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            out.add(int(token))
+        except ValueError:
+            logger.warning(f"Ignoring non-numeric antispam whitelist entry: {token!r}")
+    return out
+
+
+def detect_cross_channel_spam(
+    history: list[HistoryEntry] | deque[HistoryEntry],
+    *,
+    now: float,
+    window_seconds: float = 30.0,
+    threshold: int = 3,
+) -> SpamSignal | None:
+    """Return a signal if ``history`` looks like cross-channel spam.
+
+    Pure function, deterministic, no I/O. Fires when:
+    - the user posted in ``threshold`` or more distinct channels within
+      ``window_seconds``, OR
+    - the user posted the same content in ≥2 distinct channels within
+      the window (the "copy-paste" vector — high-precision indicator).
+    """
+    cutoff = now - window_seconds
+    fresh = [h for h in history if h.timestamp >= cutoff]
+    if not fresh:
+        return None
+
+    distinct_channels = {h.channel_id for h in fresh}
+    n_distinct = len(distinct_channels)
+
+    # Repeated-content signal: any single content_hash showed up in 2+
+    # distinct channels. This is the lower-FPR path, so we fire on it
+    # earlier than the raw distinct-channels threshold.
+    by_hash: dict[str, set[int]] = defaultdict(set)
+    for h in fresh:
+        by_hash[h.content_hash].add(h.channel_id)
+    repeated = any(len(channels) >= 2 for channels in by_hash.values())
+
+    if not repeated and n_distinct < threshold:
+        return None
+
+    # We don't carry the user_id in HistoryEntry to keep it small; the
+    # caller (``handle_message_for_spam``) re-stamps it before acting.
+    return SpamSignal(
+        user_id=0,
+        distinct_channels=n_distinct,
+        repeated_content=repeated,
+        window_seconds=window_seconds,
+        channel_ids=tuple(sorted(distinct_channels)),
+    )
+
+
+def _prune(user_id: int, now: float, window_seconds: float) -> None:
+    """Drop entries older than the window. Called on every record."""
+    history = _history[user_id]
+    cutoff = now - window_seconds
+    while history and history[0].timestamp < cutoff:
+        history.popleft()
+    if not history:
+        # Reclaim memory for inactive users; defaultdict will recreate
+        # on next access.
+        _history.pop(user_id, None)
+
+
+def _record(user_id: int, entry: HistoryEntry, window_seconds: float) -> deque[HistoryEntry]:
+    _history[user_id].append(entry)
+    _prune(user_id, entry.timestamp, window_seconds)
+    return _history[user_id]
+
+
+def _is_exempt(message: discord.Message) -> bool:
+    """Mods, bots and webhook posts are never tracked."""
+    author = message.author
+    if author.bot:
+        return True
+    perms = getattr(author, "guild_permissions", None)
+    if perms is not None and perms.manage_messages:
+        return True
+    return False
+
+
+async def _send_alert(
+    bot: commands.Bot,
+    message: discord.Message,
+    signal: SpamSignal,
+) -> None:
+    """Post a structured embed in the mods channel.
+
+    Cooldown is enforced per-user so 10 messages in a burst don't yield
+    10 identical alerts. We only post if at least
+    ``ACELERADO_ANTISPAM_ALERT_COOLDOWN_SECONDS`` has elapsed since the
+    last alert for this user.
+    """
+    now = time.time()
+    cooldown = float(get_env().ACELERADO_ANTISPAM_ALERT_COOLDOWN_SECONDS)
+    last = _alert_last_sent.get(signal.user_id)
+    if last is not None and now - last < cooldown:
+        return
+    _alert_last_sent[signal.user_id] = now
+
+    mods_id = get_env().DISCORD_MODS_CHANNEL_ID
+    if not mods_id:
+        logger.warning("antispam alert fired but DISCORD_MODS_CHANNEL_ID is not set")
+        return
+    mods_channel = bot.get_channel(mods_id)
+    if not isinstance(mods_channel, discord.abc.Messageable):
+        logger.warning(f"antispam: mods channel {mods_id} not messageable")
+        return
+
+    author = message.author
+    age_days: int | None = None
+    created_at = getattr(author, "created_at", None)
+    if isinstance(created_at, _dt.datetime):
+        age_days = max(0, (_dt.datetime.now(_dt.UTC) - created_at).days)
+
+    channels_field = ", ".join(f"<#{cid}>" for cid in signal.channel_ids) or "—"
+    embed = discord.Embed(
+        title="🚨 Possível spam cross-channel",
+        color=discord.Color.orange(),
+    )
+    embed.add_field(name="Usuário", value=author.mention, inline=False)
+    embed.add_field(
+        name="Canais",
+        value=f"{signal.distinct_channels} distintos: {channels_field}",
+        inline=False,
+    )
+    embed.add_field(
+        name="Conteúdo repetido?",
+        value="sim" if signal.repeated_content else "não",
+        inline=True,
+    )
+    embed.add_field(
+        name="Janela",
+        value=f"{int(signal.window_seconds)}s",
+        inline=True,
+    )
+    if age_days is not None:
+        embed.add_field(name="Conta criada há", value=f"{age_days} dia(s)", inline=True)
+    embed.add_field(
+        name="Última mensagem",
+        value=(message.content or "*sem texto*")[:500],
+        inline=False,
+    )
+    if hasattr(message, "jump_url"):
+        embed.add_field(name="Link", value=message.jump_url, inline=False)
+
+    await mods_channel.send(embed=embed)
+
+
+async def _delete_recent_duplicates(
+    bot: commands.Bot,
+    message: discord.Message,
+) -> None:
+    """Delete the triggering message; cross-posted copies in other
+    channels are best-effort because we don't keep handles to them.
+
+    For v1 we delete the latest message (the one that crossed the
+    threshold). The first copy stays as evidence.
+    """
+    try:
+        await message.delete()
+    except discord.HTTPException as exc:
+        logger.warning(f"antispam: failed to delete message {message.id}: {exc}")
+
+
+async def _apply_timeout(message: discord.Message) -> None:
+    member = message.author
+    minutes = get_env().ACELERADO_ANTISPAM_TIMEOUT_MINUTES
+    if not isinstance(member, discord.Member):
+        # discord.User has no timeout method — only Members in a guild
+        # can be timed out.
+        logger.warning("antispam: timeout requested but author is not a Member")
+        return
+    until = _dt.datetime.now(_dt.UTC) + _dt.timedelta(minutes=minutes)
+    try:
+        await member.timeout(until, reason="antispam: cross-channel spam")
+    except discord.HTTPException as exc:
+        logger.warning(f"antispam: failed to timeout {member}: {exc}")
+
+
+async def handle_message_for_spam(
+    bot: commands.Bot,
+    message: discord.Message,
+) -> None:
+    """Track ``message`` and react if it trips the cross-channel detector.
+
+    Safe to call on every message — exempt cases short-circuit early.
+    Never raises: errors are logged so the bot's ``on_message`` doesn't
+    have to wrap us in a guard.
+    """
+    try:
+        env = get_env()
+        if not env.ACELERADO_ANTISPAM_ENABLED:
+            return
+        if message.guild is None:
+            return  # DMs aren't cross-channel by definition
+        if _is_exempt(message):
+            return
+
+        whitelist = _parse_channel_whitelist(env.ACELERADO_ANTISPAM_CHANNEL_WHITELIST)
+        channel_id = getattr(message.channel, "id", None)
+        if channel_id is None or channel_id in whitelist:
+            return
+
+        window = float(env.ACELERADO_ANTISPAM_WINDOW_SECONDS)
+        threshold = env.ACELERADO_ANTISPAM_CROSS_CHANNEL_THRESHOLD
+        now = time.time()
+
+        entry = HistoryEntry(
+            channel_id=channel_id,
+            content_hash=_hash_content(message.content or ""),
+            timestamp=now,
+        )
+        history = _record(message.author.id, entry, window)
+
+        signal = detect_cross_channel_spam(
+            history,
+            now=now,
+            window_seconds=window,
+            threshold=threshold,
+        )
+        if signal is None:
+            return
+
+        # Re-stamp with the real user id (the pure detector is keyless).
+        signal = SpamSignal(
+            user_id=message.author.id,
+            distinct_channels=signal.distinct_channels,
+            repeated_content=signal.repeated_content,
+            window_seconds=signal.window_seconds,
+            channel_ids=signal.channel_ids,
+        )
+
+        action = (env.ACELERADO_ANTISPAM_ACTION or "alert").lower()
+        await _send_alert(bot, message, signal)
+        if action == "delete":
+            await _delete_recent_duplicates(bot, message)
+        elif action == "timeout":
+            await _delete_recent_duplicates(bot, message)
+            await _apply_timeout(message)
+        # "alert" is the default and only logs the embed.
+
+        logger.info(
+            f"antispam fired for user={message.author.id} "
+            f"channels={signal.distinct_channels} "
+            f"repeated={signal.repeated_content} action={action}"
+        )
+    except Exception:
+        logger.exception("antispam: unexpected error in handle_message_for_spam")

--- a/acelerado/bot.py
+++ b/acelerado/bot.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 import discord
 from discord.ext import commands, tasks
 
-from acelerado import review, welcome
+from acelerado import antispam, review, welcome
 from acelerado.env import get_env
 from acelerado.slash import register_commands
 from acelerado.state import AceleradoState
@@ -52,6 +52,22 @@ class AceleradoBot(commands.Bot):
             )
         )
         logger.info("Updated presence!")
+
+    async def on_message(self, message: discord.Message) -> None:
+        # Anti-spam tracking (issue #31). Disabled by default — flip
+        # ACELERADO_ANTISPAM_ENABLED on once you've validated the
+        # alerts on your server. The handler itself is fail-proof; we
+        # still wrap it so a bug here can't kill on_message dispatch.
+        if get_env().ACELERADO_ANTISPAM_ENABLED:
+            try:
+                await antispam.handle_message_for_spam(self, message)
+            except Exception as exc:
+                if self.state_handler is not None:
+                    await self.state_handler.report_error("antispam", exc)
+                else:
+                    logger.exception(f"antispam failed before state_handler ready: {exc}")
+        # commands.Bot routes prefix commands here too — preserve that.
+        await self.process_commands(message)
 
     async def on_member_join(self, member: discord.Member) -> None:
         try:

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -49,6 +49,28 @@ class EnvCfg(BaseSettings):
     # that are exempt from the "stale apoiadores" report. Comma-separated.
     ACELERADO_APOIADORES_WHITELIST: str = "eniaw"
 
+    # ------------------------------------------------------------------
+    # Anti-spam (cross-channel) — issue #31
+    # Default disabled: opt-in once an admin has watched the alerts and
+    # is comfortable with the thresholds.
+    # ------------------------------------------------------------------
+    ACELERADO_ANTISPAM_ENABLED: bool = False
+    # Sliding window in seconds for the cross-channel detector.
+    ACELERADO_ANTISPAM_WINDOW_SECONDS: int = 30
+    # Number of distinct channels (within the window) that triggers a signal.
+    ACELERADO_ANTISPAM_CROSS_CHANNEL_THRESHOLD: int = 3
+    # Reaction when a signal fires. ``alert`` only logs; ``delete`` removes
+    # cross-posted duplicates; ``timeout`` mutes the user.
+    ACELERADO_ANTISPAM_ACTION: str = "alert"
+    # Minutes to apply when ``ACELERADO_ANTISPAM_ACTION == "timeout"``.
+    ACELERADO_ANTISPAM_TIMEOUT_MINUTES: int = 10
+    # Comma-separated channel IDs exempt from cross-channel detection
+    # (e.g. cross-post hubs that legitimately mirror announcements).
+    ACELERADO_ANTISPAM_CHANNEL_WHITELIST: str = ""
+    # Per-user notification cooldown (seconds) so the bot doesn't flood
+    # the mods channel with repeated alerts for the same user.
+    ACELERADO_ANTISPAM_ALERT_COOLDOWN_SECONDS: int = 600
+
 
 def get_env() -> EnvCfg:
     """Return the merged :class:`EnvCfg`, with ``config.json`` applied on top.

--- a/tests/test_antispam.py
+++ b/tests/test_antispam.py
@@ -1,0 +1,312 @@
+"""Tests for ``acelerado.antispam`` — cross-channel spam detector (issue #31)."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from acelerado import antispam
+
+
+@pytest.fixture(autouse=True)
+def _reset_antispam_caches():
+    antispam.reset_caches()
+
+
+# ---------------------------------------------------------------------------
+# Pure detector
+# ---------------------------------------------------------------------------
+
+
+def _entry(channel_id: int, content: str = "x", ts: float = 0.0) -> antispam.HistoryEntry:
+    return antispam.HistoryEntry(
+        channel_id=channel_id,
+        content_hash=antispam._hash_content(content),
+        timestamp=ts,
+    )
+
+
+def test_detector_returns_none_on_empty_history():
+    assert antispam.detect_cross_channel_spam([], now=100.0) is None
+
+
+def test_detector_returns_none_below_threshold_and_no_repeat():
+    history = [_entry(1, "hello world", ts=99.0), _entry(2, "totally different", ts=99.5)]
+    assert (
+        antispam.detect_cross_channel_spam(history, now=100.0, window_seconds=30.0, threshold=3)
+        is None
+    )
+
+
+def test_detector_fires_on_distinct_channel_threshold():
+    history = [
+        _entry(1, "a", ts=80.0),
+        _entry(2, "b", ts=85.0),
+        _entry(3, "c", ts=90.0),
+    ]
+    sig = antispam.detect_cross_channel_spam(history, now=100.0, window_seconds=30.0, threshold=3)
+    assert sig is not None
+    assert sig.distinct_channels == 3
+    assert sig.channel_ids == (1, 2, 3)
+
+
+def test_detector_fires_on_repeated_content_in_two_channels():
+    history = [
+        _entry(1, "buy crypto now", ts=98.0),
+        _entry(2, "buy crypto now", ts=99.0),
+    ]
+    sig = antispam.detect_cross_channel_spam(history, now=100.0, window_seconds=30.0, threshold=10)
+    assert sig is not None
+    assert sig.repeated_content is True
+    assert sig.distinct_channels == 2
+
+
+def test_detector_normalizes_whitespace_and_case():
+    # Same payload modulo case + spacing collides on hash.
+    h1 = antispam._hash_content("Buy Crypto NOW!")
+    h2 = antispam._hash_content("buy   crypto    now!")
+    assert h1 == h2
+
+
+def test_detector_ignores_entries_outside_window():
+    history = [
+        _entry(1, "a", ts=10.0),
+        _entry(2, "b", ts=11.0),
+        _entry(3, "c", ts=12.0),  # all far older than window
+    ]
+    assert (
+        antispam.detect_cross_channel_spam(history, now=100.0, window_seconds=30.0, threshold=3)
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# History pruning
+# ---------------------------------------------------------------------------
+
+
+def test_record_prunes_old_entries():
+    user_id = 42
+    old = antispam.HistoryEntry(channel_id=1, content_hash="x", timestamp=0.0)
+    fresh = antispam.HistoryEntry(channel_id=2, content_hash="y", timestamp=100.0)
+
+    antispam._record(user_id, old, window_seconds=30.0)
+    history = antispam._record(user_id, fresh, window_seconds=30.0)
+
+    timestamps = [e.timestamp for e in history]
+    assert 0.0 not in timestamps
+    assert 100.0 in timestamps
+
+
+# ---------------------------------------------------------------------------
+# Message-handling integration (mocked discord)
+# ---------------------------------------------------------------------------
+
+
+def _setup_env(monkeypatch, **overrides) -> None:
+    monkeypatch.setenv("ACELERADO_ANTISPAM_ENABLED", "true")
+    monkeypatch.setenv("DISCORD_MODS_CHANNEL_ID", "777")
+    monkeypatch.setenv("ACELERADO_ANTISPAM_WINDOW_SECONDS", "30")
+    monkeypatch.setenv("ACELERADO_ANTISPAM_CROSS_CHANNEL_THRESHOLD", "3")
+    monkeypatch.setenv("ACELERADO_ANTISPAM_ACTION", "alert")
+    monkeypatch.setenv("ACELERADO_ANTISPAM_CHANNEL_WHITELIST", "")
+    monkeypatch.setenv("ACELERADO_ANTISPAM_ALERT_COOLDOWN_SECONDS", "600")
+    for k, v in overrides.items():
+        monkeypatch.setenv(k, v)
+    from acelerado import env as env_mod
+
+    env_mod.get_env.cache_clear()
+
+
+def _make_bot_with_mods_channel(messageable: bool = True) -> tuple[MagicMock, MagicMock]:
+    if messageable:
+        mods = MagicMock(spec=discord.TextChannel)
+        mods.send = AsyncMock()
+    else:
+        mods = MagicMock(spec=object)  # not Messageable
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=mods)
+    return bot, mods
+
+
+def _make_message(
+    *,
+    channel_id: int,
+    content: str = "spam",
+    author_id: int = 99,
+    is_mod: bool = False,
+    is_bot: bool = False,
+    member: bool = True,
+    account_age_days: int = 30,
+) -> MagicMock:
+    msg = MagicMock(spec=discord.Message)
+    msg.content = content
+    msg.id = channel_id * 1000 + author_id
+    msg.guild = MagicMock(spec=discord.Guild)
+    msg.guild.id = 111
+    msg.jump_url = f"https://discord.com/channels/111/{channel_id}/{msg.id}"
+
+    chan = MagicMock(spec=discord.TextChannel)
+    chan.id = channel_id
+    msg.channel = chan
+
+    author_spec = discord.Member if member else discord.User
+    author = MagicMock(spec=author_spec)
+    author.id = author_id
+    author.bot = is_bot
+    author.mention = f"<@{author_id}>"
+    author.created_at = _dt.datetime.now(_dt.UTC) - _dt.timedelta(days=account_age_days)
+    if member:
+        perms = MagicMock()
+        perms.manage_messages = is_mod
+        author.guild_permissions = perms
+        author.timeout = AsyncMock()
+    msg.author = author
+    msg.delete = AsyncMock()
+    return msg
+
+
+async def test_handle_skips_when_disabled(monkeypatch):
+    _setup_env(monkeypatch, ACELERADO_ANTISPAM_ENABLED="false")
+    bot, mods = _make_bot_with_mods_channel()
+    msg = _make_message(channel_id=1)
+    await antispam.handle_message_for_spam(bot, msg)
+    mods.send.assert_not_awaited()
+
+
+async def test_handle_skips_bots(monkeypatch):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+    for ch in (1, 2, 3):
+        await antispam.handle_message_for_spam(bot, _make_message(channel_id=ch, is_bot=True))
+    mods.send.assert_not_awaited()
+
+
+async def test_handle_skips_mods(monkeypatch):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+    for ch in (1, 2, 3):
+        await antispam.handle_message_for_spam(bot, _make_message(channel_id=ch, is_mod=True))
+    mods.send.assert_not_awaited()
+
+
+async def test_handle_skips_dms(monkeypatch):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+    msg = _make_message(channel_id=1)
+    msg.guild = None
+    await antispam.handle_message_for_spam(bot, msg)
+    mods.send.assert_not_awaited()
+
+
+async def test_handle_skips_whitelisted_channel(monkeypatch):
+    _setup_env(monkeypatch, ACELERADO_ANTISPAM_CHANNEL_WHITELIST="1,2,3")
+    bot, mods = _make_bot_with_mods_channel()
+    for ch in (1, 2, 3):
+        await antispam.handle_message_for_spam(bot, _make_message(channel_id=ch))
+    mods.send.assert_not_awaited()
+
+
+async def test_handle_alerts_on_repeated_content_cross_channel(monkeypatch):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+
+    # Same content posted in two channels by the same user.
+    await antispam.handle_message_for_spam(bot, _make_message(channel_id=1, content="buy crypto"))
+    await antispam.handle_message_for_spam(bot, _make_message(channel_id=2, content="buy crypto"))
+
+    mods.send.assert_awaited_once()
+    embed = mods.send.await_args.kwargs["embed"]
+    assert "spam" in embed.title.lower()
+
+
+async def test_handle_alerts_after_threshold_distinct_channels(monkeypatch):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+
+    # Three different posts in three different channels — but distinct
+    # contents (no repeat-content match), so only the threshold fires.
+    for ch, content in [(1, "alpha"), (2, "beta"), (3, "gamma")]:
+        await antispam.handle_message_for_spam(bot, _make_message(channel_id=ch, content=content))
+
+    mods.send.assert_awaited_once()
+
+
+async def test_alert_includes_account_age(monkeypatch):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+    for ch in (1, 2):
+        await antispam.handle_message_for_spam(
+            bot, _make_message(channel_id=ch, content="same", account_age_days=2)
+        )
+    embed = mods.send.await_args.kwargs["embed"]
+    field_names = {f.name for f in embed.fields}
+    assert "Conta criada há" in field_names
+
+
+async def test_alert_cooldown_prevents_flood(monkeypatch):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+
+    # Trip detector twice in quick succession — second alert should be
+    # suppressed by the per-user cooldown.
+    for ch in (1, 2):
+        await antispam.handle_message_for_spam(bot, _make_message(channel_id=ch, content="same"))
+    for ch in (3, 4):
+        await antispam.handle_message_for_spam(bot, _make_message(channel_id=ch, content="same"))
+
+    assert mods.send.await_count == 1
+
+
+async def test_action_delete_removes_message(monkeypatch):
+    _setup_env(monkeypatch, ACELERADO_ANTISPAM_ACTION="delete")
+    bot, _ = _make_bot_with_mods_channel()
+
+    msg1 = _make_message(channel_id=1, content="dup")
+    msg2 = _make_message(channel_id=2, content="dup")
+    await antispam.handle_message_for_spam(bot, msg1)
+    await antispam.handle_message_for_spam(bot, msg2)
+
+    # Only the triggering (second) message gets deleted in v1.
+    msg2.delete.assert_awaited_once()
+
+
+async def test_action_timeout_calls_member_timeout(monkeypatch):
+    _setup_env(monkeypatch, ACELERADO_ANTISPAM_ACTION="timeout")
+    bot, _ = _make_bot_with_mods_channel()
+
+    msg1 = _make_message(channel_id=1, content="dup")
+    msg2 = _make_message(channel_id=2, content="dup")
+    await antispam.handle_message_for_spam(bot, msg1)
+    await antispam.handle_message_for_spam(bot, msg2)
+
+    msg2.author.timeout.assert_awaited_once()
+
+
+async def test_action_alert_does_not_delete_or_timeout(monkeypatch):
+    _setup_env(monkeypatch)  # default action=alert
+    bot, _ = _make_bot_with_mods_channel()
+
+    msg1 = _make_message(channel_id=1, content="dup")
+    msg2 = _make_message(channel_id=2, content="dup")
+    await antispam.handle_message_for_spam(bot, msg1)
+    await antispam.handle_message_for_spam(bot, msg2)
+
+    msg2.delete.assert_not_awaited()
+    msg2.author.timeout.assert_not_awaited()
+
+
+async def test_handle_swallows_unexpected_errors(monkeypatch, caplog):
+    _setup_env(monkeypatch)
+    bot, mods = _make_bot_with_mods_channel()
+    mods.send.side_effect = RuntimeError("boom")
+
+    # Trip detector — alert path will raise, but the handler must not.
+    for ch in (1, 2):
+        await antispam.handle_message_for_spam(bot, _make_message(channel_id=ch, content="same"))
+    # Still only one attempted send; second was suppressed by detector
+    # cooldown logic — we mainly assert no exception propagated.
+    assert any("antispam" in r.message and r.levelname == "ERROR" for r in caplog.records)


### PR DESCRIPTION
Closes #31.

## Summary
- New `acelerado/antispam.py` with a pure `detect_cross_channel_spam` (sliding window, easy to unit-test) and an async `handle_message_for_spam` wired into `on_message`.
- Detector fires on either signal: same content posted in ≥2 channels (high-precision copy-paste vector) or N distinct channels within the window.
- Configurable actions: `alert` (default — embed in mods channel only), `delete` (drops the triggering message), `timeout` (also mutes the author for `ACELERADO_ANTISPAM_TIMEOUT_MINUTES`).
- Exemptions: mods (`manage_messages`), bots, DMs, and whitelisted channel IDs. Per-user mods-channel alert cooldown to avoid flood.
- Defaults to **disabled** so the feature is opt-in once the admin has eyeballed the alerts on their server.

## New env vars
| Key | Default | Purpose |
|---|---|---|
| `ACELERADO_ANTISPAM_ENABLED` | `false` | master switch |
| `ACELERADO_ANTISPAM_WINDOW_SECONDS` | `30` | sliding window |
| `ACELERADO_ANTISPAM_CROSS_CHANNEL_THRESHOLD` | `3` | distinct-channel trigger |
| `ACELERADO_ANTISPAM_ACTION` | `alert` | `alert` / `delete` / `timeout` |
| `ACELERADO_ANTISPAM_TIMEOUT_MINUTES` | `10` | duration when action=timeout |
| `ACELERADO_ANTISPAM_CHANNEL_WHITELIST` | `""` | comma-separated channel IDs exempt |
| `ACELERADO_ANTISPAM_ALERT_COOLDOWN_SECONDS` | `600` | per-user alert cooldown |

## Test plan
- [x] `uv run pytest` — 243 passed (20 new in `tests/test_antispam.py`)
- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run mypy acelerado`
- [ ] After merge: flip `ACELERADO_ANTISPAM_ENABLED=true` on staging via `/config set` and watch the mods channel for false positives before escalating action to `delete`/`timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)