### PR TITLE
feat(challenges): integração inicial com acelerado-desafios (Fases 1+2+3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ acelerado/
   config.py       # Settings overlay — config.json on top of EnvCfg
                   # (atomic write, set/unset/reload, secret-key guard)
   log.py          # setup_logging() with RichHandler
+  challenges/     # monthly performance-challenge integration (issue #37)
+    spec.py       #   pydantic Spec for spec.json (extra="allow")
+    github.py     #   async httpx client for the desafios repo
+    state.py      #   challenges_state.json — announce idempotency
+    announce.py   #   metric-aware copy renderer
 scripts/
   send_token.sh   # SCP token.pickle to a remote host
 .github/workflows/
@@ -69,6 +74,7 @@ token.pickle      # cached OAuth user token
    - Skip if not yet processed (unless it's a livestream).
    - Skip vertical videos (Shorts).
    - Message wording differs for livestream / members-only / regular video.
+4. **Monthly challenges** (issue #37, Phase 1) — gated by `ACELERADO_CHALLENGES_ENABLED`; on the configured day/hour, query the `wainejr/acelerado-desafios` repo via the GitHub REST API, locate the `YYYY-MM-*` folder for the current month, fetch its `spec.json`, and post a metric-aware announcement in `DISCORD_CHALLENGES_CHANNEL_ID`. Idempotency lives in `challenges_state.json` (slug-keyed, not month-keyed). `/desafio` slash command exposes the same lookup ephemerally.
 
 ## Required env (`.env`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,10 @@ acelerado/
   log.py          # setup_logging() with RichHandler
   challenges/     # monthly performance-challenge integration (issue #37)
     spec.py       #   pydantic Spec for spec.json (extra="allow")
-    github.py     #   async httpx client for the desafios repo
-    state.py      #   challenges_state.json — announce idempotency
-    announce.py   #   metric-aware copy renderer
+    github.py     #   async httpx client for the desafios repo + history cache
+    state.py      #   challenges_state.json — announce + results posted/dismissed/last_remind
+    announce.py   #   metric-aware announcement copy renderer
+    results.py    #   pydantic Results + metric-aware results post renderer (Phase 3)
 scripts/
   send_token.sh   # SCP token.pickle to a remote host
 .github/workflows/
@@ -74,7 +75,11 @@ token.pickle      # cached OAuth user token
    - Skip if not yet processed (unless it's a livestream).
    - Skip vertical videos (Shorts).
    - Message wording differs for livestream / members-only / regular video.
-4. **Monthly challenges** (issue #37, Phase 1) — gated by `ACELERADO_CHALLENGES_ENABLED`; on the configured day/hour, query the `wainejr/acelerado-desafios` repo via the GitHub REST API, locate the `YYYY-MM-*` folder for the current month, fetch its `spec.json`, and post a metric-aware announcement in `DISCORD_CHALLENGES_CHANNEL_ID`. Idempotency lives in `challenges_state.json` (slug-keyed, not month-keyed). `/desafio` slash command exposes the same lookup ephemerally.
+4. **Monthly challenges** (issue #37) — gated by `ACELERADO_CHALLENGES_ENABLED`. Two tick steps:
+   - `_announce_new_challenge` (Phase 1): on the configured day/hour, query the `wainejr/acelerado-desafios` repo via the GitHub REST API, locate the `YYYY-MM-*` folder for the current month, fetch its `spec.json`, and post a metric-aware announcement in `DISCORD_CHALLENGES_CHANNEL_ID`. Idempotency lives in `challenges_state.json` (slug-keyed, not month-keyed).
+   - `_remind_pending_results` (Phase 3): for every challenge folder whose `YYYY-MM` is in the past and which is neither posted nor dismissed in state, post a 1×/24h reminder in the **log channel** so the operator gets nudged to run `/desafio resultados <slug>` (or `/desafio resultados-skip <slug>` to mute).
+
+   `/desafio` is a slash group: `status` (current challenge + open-PR count, public), `resultados <slug>` (admin — fetches `results.json`, renders metric-aware draft, posts to `DISCORD_REVIEW_CHANNEL_ID` with the editorial `EditableDraftView`), `resultados-skip <slug>` (admin — silences reminders), `historico` (top-3 of past challenges, 6h cache, footer shows last fetch).
 
 ## Required env (`.env`)
 

--- a/acelerado/challenges/__init__.py
+++ b/acelerado/challenges/__init__.py
@@ -1,0 +1,7 @@
+"""Monthly performance-challenge integration (issue #37).
+
+Phase 1 surface: discover the active challenge from the
+``wainejr/acelerado-desafios`` repo, announce it once per month in a
+configured channel, and expose ``/desafio`` for quick lookup. Submission
+polling and the results-draft pipeline live in later phases.
+"""

--- a/acelerado/challenges/announce.py
+++ b/acelerado/challenges/announce.py
@@ -1,0 +1,79 @@
+"""Render the monthly challenge announcement message.
+
+Copy is in Portuguese (consistent with the rest of the bot) and adapts
+to the spec's primary metric — minimizing time reads differently from
+maximizing PSNR. Unknown metrics fall through to a generic
+"<direction> <metric>" sentence rather than failing, so a future
+challenge with a novel metric still announces cleanly.
+"""
+
+from __future__ import annotations
+
+from acelerado.challenges.spec import Spec
+
+# Per-metric copy for the headline. Phrased as a complete sentence so
+# the renderer can drop it in without grammar gymnastics.
+_METRIC_COPY: dict[tuple[str, str], str] = {
+    ("time_ms", "min"): "Minimizar **tempo de execução**.",
+    ("time_ms_per_image", "min"): "Minimizar **tempo por imagem**.",
+    ("peak_rss_mb", "min"): "Minimizar **pico de memória (RSS)**.",
+    ("disk_write_mb", "min"): "Minimizar **escrita em disco**.",
+    ("binary_size_bytes", "min"): "Minimizar **tamanho do binário**.",
+    ("code_size_bytes", "min"): "Minimizar **tamanho do código-fonte**.",
+    ("psnr_mean_db", "max"): "Maximizar **PSNR médio** (qualidade da reconstrução).",
+    ("quality", "max"): "Maximizar **qualidade da saída**.",
+    ("quality", "min"): "Minimizar **erro da saída**.",
+}
+
+_DIRECTION_VERB = {"min": "minimizar", "max": "maximizar"}
+
+
+def _metric_sentence(spec: Spec) -> str:
+    key = (spec.primary_metric, spec.direction)
+    if key in _METRIC_COPY:
+        return _METRIC_COPY[key]
+    verb = _DIRECTION_VERB.get(spec.direction, spec.direction)
+    return f"{verb.capitalize()} **`{spec.primary_metric}`**."
+
+
+# Caps formatter — same idea: known keys get a polished line, unknown
+# keys round-trip as ``key: value`` so nothing is silently hidden.
+def format_cap(key: str, value: object) -> str:
+    if key in {"time_ms", "time_ms_per_image"}:
+        suffix = " por imagem" if key == "time_ms_per_image" else ""
+        return f"⏱ {value} ms{suffix}"
+    if key == "peak_rss_mb":
+        return f"💾 {value} MB de RAM"
+    if key == "disk_write_mb":
+        return f"📝 {value} MB de escrita em disco"
+    if key == "binary_size_bytes":
+        return f"📦 {value} bytes (binário)"
+    if key == "code_size_bytes":
+        return f"📜 {value} bytes (código-fonte)"
+    return f"{key}: {value}"
+
+
+def render_announcement(spec: Spec) -> str:
+    """Return the message body to post in the announcements channel."""
+    lines = [
+        f"@everyone 🏁 **Desafio de {spec.month} — {spec.title}**",
+        "",
+        _metric_sentence(spec),
+    ]
+    if spec.caps:
+        lines.append("")
+        lines.append("**Limites:**")
+        for cap_key, cap_value in spec.caps.items():
+            lines.append(f"• {format_cap(cap_key, cap_value)}")
+    lines.append("")
+    lines.append(f"📖 Enunciado: {spec.site_url}")
+    lines.append(
+        "🐳 Submissão via PR no repo "
+        "[acelerado-desafios](https://github.com/wainejr/acelerado-desafios)."
+    )
+    return "\n".join(lines)
+
+
+def render_short_status(spec: Spec) -> str:
+    """One-line summary — used by ``/desafio`` for the active challenge."""
+    return f"**{spec.month} — {spec.title}** · {_metric_sentence(spec)}"

--- a/acelerado/challenges/github.py
+++ b/acelerado/challenges/github.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 import logging
 import os
 import re
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
 
+from acelerado.challenges.results import Results, load_results
 from acelerado.challenges.spec import Spec, load_spec
 
 logger = logging.getLogger(__name__)
@@ -154,6 +156,92 @@ async def find_current_spec(
         if slug_month(slug) == month:
             return await fetch_spec(repo, slug, token=token)
     return None
+
+
+async def fetch_results(
+    repo: str,
+    slug: str,
+    token: str | None = None,
+) -> Results | None:
+    """Fetch and validate ``<slug>/results.json``.
+
+    Returns ``None`` when the file doesn't exist (404 from raw) — that's
+    a normal state during the active month before benchmarks have run.
+    Other HTTP / JSON errors raise :class:`GitHubError`.
+    """
+    token = _resolve_token(token)
+    url = f"https://raw.githubusercontent.com/{repo}/HEAD/{slug}/results.json"
+    async with httpx.AsyncClient(
+        headers=_headers(token),
+        timeout=DEFAULT_TIMEOUT,
+    ) as client:
+        try:
+            response = await client.get(url)
+        except httpx.HTTPError as exc:
+            raise GitHubError(f"network error fetching {url}: {exc}") from exc
+        if response.status_code == 404:
+            return None
+        if response.status_code >= 400:
+            raise GitHubError(f"{response.status_code} from {url}: {response.text[:200]}")
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise GitHubError(f"invalid JSON from {url}: {exc}") from exc
+    return load_results(data)
+
+
+async def list_past_results(repo: str, token: str | None = None) -> list[Results]:
+    """Return every ``results.json`` found under the repo's challenge folders.
+
+    Slugs that don't have a ``results.json`` yet are skipped silently —
+    typical for the active month. Order: most-recent slug first
+    (lexicographic on ``YYYY-MM`` sorts chronologically).
+    """
+    slugs = await list_challenge_slugs(repo, token=token)
+    out: list[Results] = []
+    for slug in sorted(slugs, reverse=True):
+        results = await fetch_results(repo, slug, token=token)
+        if results is not None:
+            out.append(results)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cached historic results
+#
+# The history listing walks every challenge folder and fetches each
+# results.json — that's N+1 requests against GitHub. Caching the
+# aggregate per-repo for a few hours keeps ``/desafio historico`` snappy
+# and stays well under rate limits even with steady use.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_HISTORY_TTL = timedelta(hours=6)
+_history_cache: dict[str, tuple[datetime, list[Results]]] = {}
+
+
+def clear_history_cache() -> None:
+    """Drop the in-memory cache (test helper / forced refresh)."""
+    _history_cache.clear()
+
+
+async def get_cached_history(
+    repo: str,
+    *,
+    ttl: timedelta = _DEFAULT_HISTORY_TTL,
+    token: str | None = None,
+) -> tuple[list[Results], datetime]:
+    """Return ``(results, fetched_at)`` honoring a per-repo TTL.
+
+    The timestamp travels with the data so callers can show *"última
+    atualização: …"* without re-checking the cache themselves.
+    """
+    now = datetime.now(UTC)
+    cached = _history_cache.get(repo)
+    if cached is not None and (now - cached[0]) < ttl:
+        return cached[1], cached[0]
+    fresh = await list_past_results(repo, token=token)
+    _history_cache[repo] = (now, fresh)
+    return fresh, now
 
 
 async def count_open_submissions(repo: str, token: str | None = None) -> int:

--- a/acelerado/challenges/github.py
+++ b/acelerado/challenges/github.py
@@ -154,3 +154,28 @@ async def find_current_spec(
         if slug_month(slug) == month:
             return await fetch_spec(repo, slug, token=token)
     return None
+
+
+async def count_open_submissions(repo: str, token: str | None = None) -> int:
+    """Return the number of open pull requests targeting ``repo``.
+
+    For the challenges repo every open PR is, by convention, a
+    submission — there's no other ongoing work in that repo. So PR
+    count is the cheapest signal of community activity. We don't list
+    authors anywhere; the URL we surface in ``/desafio`` lets the user
+    inspect them directly on GitHub if they want.
+
+    Pagination: GitHub's PR endpoint defaults to 30 per page and caps at
+    100. A monthly challenge with >100 open PRs would be a very nice
+    problem to have; if we ever hit it, we'll add `?page=`. For now we
+    cap at one page (``per_page=100``) and trust the cap.
+    """
+    token = _resolve_token(token)
+    async with _client(token) as client:
+        prs = await _get_json(
+            client,
+            f"/repos/{repo}/pulls?state=open&per_page=100",
+        )
+    if not isinstance(prs, list):
+        raise GitHubError(f"expected list from /pulls, got {type(prs).__name__}")
+    return len(prs)

--- a/acelerado/challenges/github.py
+++ b/acelerado/challenges/github.py
@@ -1,0 +1,156 @@
+"""Async GitHub client for the challenges repo.
+
+We talk to the public REST API (``api.github.com``). Anonymous calls are
+limited to 60/h per IP; that's more than enough for a 5-minute tick, but
+if ``GITHUB_TOKEN`` is set in the environment we use it for the larger
+quota. The token is treated as a secret — never written to
+``config.json``, only read at request time.
+
+Errors are surfaced as :class:`GitHubError` so callers (the tick step)
+can route them through :meth:`AceleradoState.report_error` without
+caring whether the failure came from DNS, HTTP, or JSON.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+import httpx
+
+from acelerado.challenges.spec import Spec, load_spec
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://api.github.com"
+DEFAULT_TIMEOUT = 10.0
+USER_AGENT = "acelerado-bot (+https://github.com/wainejr/discord)"
+
+# Folder names look like ``2026-05-deblur``. The leading ``YYYY-MM`` is
+# the source of truth for "which challenge is current".
+_SLUG_RE = re.compile(r"^(?P<month>\d{4}-(?:0[1-9]|1[0-2]))-[a-z0-9][a-z0-9-]*$")
+
+
+class GitHubError(RuntimeError):
+    """Wraps any failure talking to GitHub (network, HTTP, JSON shape)."""
+
+
+def _headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": USER_AGENT,
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _resolve_token(explicit: str | None) -> str | None:
+    """Return the token to use, preferring the explicit arg over env."""
+    if explicit:
+        return explicit
+    return os.environ.get("GITHUB_TOKEN") or None
+
+
+async def _get_json(client: httpx.AsyncClient, url: str) -> Any:
+    try:
+        response = await client.get(url)
+    except httpx.HTTPError as exc:
+        raise GitHubError(f"network error fetching {url}: {exc}") from exc
+
+    # Surface low rate-limit budgets so the operator notices before the
+    # bot starts silently failing every tick.
+    remaining = response.headers.get("X-RateLimit-Remaining")
+    if remaining is not None and remaining.isdigit() and int(remaining) <= 5:
+        logger.warning(f"GitHub rate limit low: {remaining} requests left")
+
+    if response.status_code >= 400:
+        raise GitHubError(f"{response.status_code} from {url}: {response.text[:200]}")
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise GitHubError(f"invalid JSON from {url}: {exc}") from exc
+
+
+def _client(token: str | None) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url=API_BASE,
+        headers=_headers(token),
+        timeout=DEFAULT_TIMEOUT,
+    )
+
+
+async def list_challenge_slugs(repo: str, token: str | None = None) -> list[str]:
+    """Return slugs of every challenge folder in the repo root.
+
+    Folders that don't match ``YYYY-MM-<name>`` are skipped silently —
+    the README, ``LICENSE``, ``SUBMISSION.md``, etc. live in the same
+    place and we don't want to log noise about them every tick.
+    """
+    token = _resolve_token(token)
+    async with _client(token) as client:
+        entries = await _get_json(client, f"/repos/{repo}/contents")
+    if not isinstance(entries, list):
+        raise GitHubError(f"expected list from /contents, got {type(entries).__name__}")
+
+    slugs: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("type") != "dir":
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and _SLUG_RE.match(name):
+            slugs.append(name)
+    return sorted(slugs)
+
+
+async def fetch_spec(repo: str, slug: str, token: str | None = None) -> Spec:
+    """Fetch and validate ``<slug>/spec.json`` from the repo's default branch."""
+    token = _resolve_token(token)
+    # Use the raw endpoint — the contents API would return base64 we'd
+    # then have to decode. Raw is plain JSON, smaller, and respects the
+    # default branch automatically.
+    url = f"https://raw.githubusercontent.com/{repo}/HEAD/{slug}/spec.json"
+    async with httpx.AsyncClient(
+        headers=_headers(token),
+        timeout=DEFAULT_TIMEOUT,
+    ) as client:
+        try:
+            response = await client.get(url)
+        except httpx.HTTPError as exc:
+            raise GitHubError(f"network error fetching {url}: {exc}") from exc
+        if response.status_code >= 400:
+            raise GitHubError(f"{response.status_code} from {url}: {response.text[:200]}")
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise GitHubError(f"invalid JSON from {url}: {exc}") from exc
+    return load_spec(data)
+
+
+def slug_month(slug: str) -> str | None:
+    """Extract the ``YYYY-MM`` prefix from a slug, or ``None`` if unparseable."""
+    match = _SLUG_RE.match(slug)
+    return match.group("month") if match else None
+
+
+async def find_current_spec(
+    repo: str,
+    month: str,
+    token: str | None = None,
+) -> Spec | None:
+    """Locate and fetch the spec for the challenge whose slug matches ``month``.
+
+    Returns ``None`` if no folder for that month exists yet — that's a
+    normal state on the 1st of the month before publication.
+    """
+    slugs = await list_challenge_slugs(repo, token=token)
+    for slug in slugs:
+        if slug_month(slug) == month:
+            return await fetch_spec(repo, slug, token=token)
+    return None

--- a/acelerado/challenges/results.py
+++ b/acelerado/challenges/results.py
@@ -1,0 +1,196 @@
+"""Schema + renderer for ``results.json``.
+
+Each challenge ends with the maintainer committing a ``results.json``
+to ``<slug>/`` in the desafios repo. Shape is deliberately loose —
+metrics vary per challenge (PSNR for deblur, time for mandelbrot,
+peak RSS for ext-sort, …) — so :class:`Entry.metrics` is an opaque
+dict the renderer formats by name. Unknown metric keys fall through
+to ``str(value)``.
+
+The renderer produces a Markdown draft in PT-BR; it never posts on its
+own. The draft flows through :class:`acelerado.review.EditableDraftView`
+for human approval before going public.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Metric direction is duplicated in spec.json; results.json carries it
+# again for self-containment so the renderer doesn't need both files in
+# memory just to know which way the ranking points.
+
+
+class Entry(BaseModel):
+    """One ranked submission. ``metrics`` mirrors per-run fields."""
+
+    model_config = ConfigDict(extra="allow")
+
+    rank: int
+    user: str
+    language: str | None = None
+    metrics: dict[str, Any] = Field(default_factory=dict)
+
+
+class Disqualified(BaseModel):
+    """One entry that failed validation or busted a cap."""
+
+    model_config = ConfigDict(extra="allow")
+
+    user: str
+    reason: str
+
+
+class Results(BaseModel):
+    """Full results payload for one challenge.
+
+    Extra fields at the top level are kept (``extra="allow"``) so the
+    bot doesn't need to know about every future enrichment (timing
+    breakdowns, hardware notes, …) just to render the post.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    slug: str
+    primary_metric: str
+    direction: str
+    ranking: list[Entry] = Field(default_factory=list)
+    disqualified: list[Disqualified] = Field(default_factory=list)
+
+
+def load_results(data: dict[str, Any]) -> Results:
+    return Results.model_validate(data)
+
+
+def load_results_file(path: Path) -> Results:
+    return load_results(json.loads(path.read_text(encoding="utf-8")))
+
+
+# ---------------------------------------------------------------------------
+# Metric value formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_time_ms(value: Any) -> str:
+    """Render a millisecond value as either ``ms`` or ``s`` depending on size."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if v >= 1000:
+        return f"{v / 1000:.2f} s"
+    return f"{v:.0f} ms"
+
+
+def _format_bytes(value: Any) -> str:
+    """Humanize a byte count with KB/MB suffixes."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if v >= 1_000_000:
+        return f"{v / 1_000_000:.2f} MB"
+    if v >= 1_000:
+        return f"{v / 1_000:.1f} KB"
+    return f"{v:.0f} B"
+
+
+def _format_float(value: Any, suffix: str) -> str:
+    try:
+        return f"{float(value):.2f} {suffix}".rstrip()
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def format_metric_value(metric: str, value: Any) -> str:
+    """Format ``value`` according to ``metric`` semantics.
+
+    Unknown metrics fall through to ``str(value)`` — better than
+    raising on a future metric we haven't taught the renderer about.
+    """
+    if metric in {"time_ms", "time_ms_per_image"}:
+        rendered = _format_time_ms(value)
+        if metric == "time_ms_per_image":
+            return f"{rendered}/img"
+        return rendered
+    if metric in {"peak_rss_mb", "disk_write_mb"}:
+        try:
+            return f"{float(value):.0f} MB"
+        except (TypeError, ValueError):
+            return str(value)
+    if metric in {"binary_size_bytes", "code_size_bytes"}:
+        return _format_bytes(value)
+    if metric == "psnr_mean_db":
+        return _format_float(value, "dB")
+    if metric == "quality":
+        return _format_float(value, "")
+    return str(value)
+
+
+_PODIUM_EMOJI = {1: "🥇", 2: "🥈", 3: "🥉"}
+
+
+def _entry_line(entry: Entry, primary: str) -> str:
+    """Headline for one ranking entry — rank emoji + user + primary metric."""
+    emoji = _PODIUM_EMOJI.get(entry.rank, "🔹")
+    primary_value = entry.metrics.get(primary, "—")
+    primary_str = format_metric_value(primary, primary_value)
+    return f"{emoji} **{entry.rank}º:** @{entry.user} — **{primary_str}**"
+
+
+def _entry_secondary_line(entry: Entry, primary: str) -> str | None:
+    """Compact stats line shown below the headline.
+
+    Includes secondary metrics (anything in ``entry.metrics`` other than
+    the primary) plus the language if known. Returns ``None`` if there's
+    nothing meaningful to show — caller skips the line entirely.
+    """
+    parts: list[str] = []
+    for key, value in entry.metrics.items():
+        if key == primary:
+            continue
+        parts.append(format_metric_value(key, value))
+    if entry.language:
+        parts.append(entry.language)
+    return " · ".join(parts) if parts else None
+
+
+def render_results_post(results: Results) -> str:
+    """Render the full Markdown post for posting in the challenges channel."""
+    lines = [f"## 🏁 Resultados — {results.slug}", ""]
+
+    if not results.ranking:
+        lines.append("_Sem submissões válidas neste desafio._")
+    else:
+        # Top 3 each get a headline + secondary line (when applicable);
+        # ranks 4+ collapse into a one-liner per entry to keep posts
+        # short on busy months.
+        primary = results.primary_metric
+        top = [e for e in results.ranking if e.rank <= 3]
+        rest = [e for e in results.ranking if e.rank > 3]
+
+        for entry in top:
+            lines.append(_entry_line(entry, primary))
+            secondary = _entry_secondary_line(entry, primary)
+            if secondary:
+                lines.append(f"   {secondary}")
+            lines.append("")
+
+        if rest:
+            lines.append("**Demais participantes:**")
+            for entry in rest:
+                lines.append(f"• {_entry_line(entry, primary)}")
+            lines.append("")
+
+    if results.disqualified:
+        lines.append("---")
+        lines.append(f"**Desclassificados ({len(results.disqualified)}):**")
+        for d in results.disqualified:
+            lines.append(f"• @{d.user} — {d.reason}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/acelerado/challenges/spec.py
+++ b/acelerado/challenges/spec.py
@@ -1,0 +1,64 @@
+"""Schema for a challenge ``spec.json``.
+
+Each challenge folder in ``wainejr/acelerado-desafios`` carries a
+``spec.json`` that declares the primary metric, direction, hard caps,
+and metadata about the input format. The bot only needs a thin slice of
+that to render its announcement and ``/desafio`` reply, but the file
+contents may grow over time — extra fields are preserved via pydantic's
+``extra="allow"`` so we can round-trip them when needed.
+
+Validation is intentionally permissive: an unknown ``primary_metric`` or
+``direction`` doesn't reject the spec — it just falls back to generic
+copy in the renderer. The bot announcing a malformed challenge is worse
+than announcing a slightly-uglier one.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# YYYY-MM
+_MONTH_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+
+
+class Spec(BaseModel):
+    """Subset of ``spec.json`` the bot reads.
+
+    Unknown fields are kept in :attr:`model_extra` so we don't lose
+    things like ``image``/``psf``/``noise``/``bench`` that the harness
+    cares about but the bot doesn't.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    title: str
+    month: str = Field(pattern=_MONTH_RE.pattern)
+    primary_metric: str
+    direction: str
+    caps: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def slug(self) -> str:
+        """Folder name in the repo: ``<month>-<name>``."""
+        return f"{self.month}-{self.name}"
+
+    @property
+    def site_url(self) -> str:
+        """Public GitHub Pages URL for this challenge's page."""
+        return f"https://wainejr.github.io/acelerado-desafios/desafios/{self.slug}/"
+
+
+def load_spec(data: dict[str, Any]) -> Spec:
+    """Validate ``data`` (already-parsed JSON) into a :class:`Spec`."""
+    return Spec.model_validate(data)
+
+
+def load_spec_file(path: Path) -> Spec:
+    """Read + parse + validate a ``spec.json`` from disk."""
+    return load_spec(json.loads(path.read_text(encoding="utf-8")))

--- a/acelerado/challenges/state.py
+++ b/acelerado/challenges/state.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -69,6 +70,73 @@ class ChallengesState:
         if slug in announced:
             return
         announced.append(slug)
+        self._flush()
+
+    # ------------------------------------------------------------------
+    # Results posting (Phase 3) — manual via /desafio resultados.
+    # The state tracks slugs already drafted (so we don't re-cobrar
+    # them) and slugs explicitly skipped (operator told us to stop).
+    # ``last_remind_at`` rate-limits the reminder step to 1×/24h per
+    # slug regardless of tick frequency.
+    # ------------------------------------------------------------------
+
+    def _list(self, key: str) -> list[str]:
+        value = self._data.get(key, [])
+        return value if isinstance(value, list) else []
+
+    def is_results_posted(self, slug: str) -> bool:
+        return slug in self._list("results_posted")
+
+    def mark_results_posted(self, slug: str) -> None:
+        posted = self._data.setdefault("results_posted", [])
+        if not isinstance(posted, list):
+            posted = []
+            self._data["results_posted"] = posted
+        if slug in posted:
+            return
+        posted.append(slug)
+        self._flush()
+
+    def is_results_dismissed(self, slug: str) -> bool:
+        return slug in self._list("results_dismissed")
+
+    def mark_results_dismissed(self, slug: str) -> None:
+        dismissed = self._data.setdefault("results_dismissed", [])
+        if not isinstance(dismissed, list):
+            dismissed = []
+            self._data["results_dismissed"] = dismissed
+        if slug in dismissed:
+            return
+        dismissed.append(slug)
+        self._flush()
+
+    def should_remind(self, slug: str, *, cooldown: timedelta = timedelta(hours=24)) -> bool:
+        """Return ``True`` iff we haven't reminded about ``slug`` recently.
+
+        Posted/dismissed slugs short-circuit to ``False`` regardless of
+        the cooldown — once acted on, the reminder is done forever.
+        """
+        if self.is_results_posted(slug) or self.is_results_dismissed(slug):
+            return False
+        last = (
+            self._data.get("last_remind_at", {}).get(slug)
+            if isinstance(self._data.get("last_remind_at"), dict)
+            else None
+        )
+        if last is None:
+            return True
+        try:
+            last_dt = datetime.fromisoformat(last)
+        except (TypeError, ValueError):
+            return True
+        return datetime.now(UTC) - last_dt >= cooldown
+
+    def mark_reminded(self, slug: str) -> None:
+        bucket = self._data.setdefault("last_remind_at", {})
+        if not isinstance(bucket, dict):
+            bucket = {}
+            self._data["last_remind_at"] = bucket
+        bucket[slug] = datetime.now(UTC).isoformat()
         self._flush()
 
     @property

--- a/acelerado/challenges/state.py
+++ b/acelerado/challenges/state.py
@@ -1,0 +1,77 @@
+"""Persistent state for the challenge tick.
+
+A single JSON file (``challenges_state.json``) tracks what we've already
+announced so the tick is idempotent across bot restarts. Phase 1 only
+needs the announcement marker; later phases will tack on submission
+counts and the results-posted flag.
+
+Atomic write follows the same pattern as :mod:`acelerado.config` —
+``.tmp`` + ``replace`` so external readers (TUI, healthcheck) never see
+a half-written file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CHALLENGES_STATE_PATH = Path("challenges_state.json")
+
+
+class ChallengesState:
+    """In-memory view backed by ``challenges_state.json``.
+
+    The file is the source of truth — every mutation flushes
+    immediately. This keeps the surface tiny: callers don't need to
+    remember to ``save()``.
+    """
+
+    def __init__(self, path: Path = CHALLENGES_STATE_PATH) -> None:
+        self.path = path
+        self._data: dict[str, Any] = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(f"{self.path} unreadable ({exc}); starting fresh")
+            return {}
+        if not isinstance(data, dict):
+            logger.warning(f"{self.path} must be a JSON object; starting fresh")
+            return {}
+        return data
+
+    def _flush(self) -> None:
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(self._data, indent=2, sort_keys=True), encoding="utf-8")
+        tmp.replace(self.path)
+
+    # ------------------------------------------------------------------
+    # Announce idempotency — keyed by the challenge slug, not the month,
+    # so a typo-fix that renames the folder mid-month re-announces.
+    # ------------------------------------------------------------------
+
+    def is_announced(self, slug: str) -> bool:
+        announced = self._data.get("announced", [])
+        return isinstance(announced, list) and slug in announced
+
+    def mark_announced(self, slug: str) -> None:
+        announced = self._data.setdefault("announced", [])
+        if not isinstance(announced, list):
+            announced = []
+            self._data["announced"] = announced
+        if slug in announced:
+            return
+        announced.append(slug)
+        self._flush()
+
+    @property
+    def raw(self) -> dict[str, Any]:
+        """Read-only snapshot — for diagnostics / future phases."""
+        return dict(self._data)

--- a/acelerado/config.py
+++ b/acelerado/config.py
@@ -52,6 +52,7 @@ CHANNEL_KEYS: frozenset[str] = frozenset(
         "DISCORD_WELCOME_CHANNEL_ID",
         "DISCORD_MODS_CHANNEL_ID",
         "DISCORD_REVIEW_CHANNEL_ID",
+        "DISCORD_CHALLENGES_CHANNEL_ID",
     }
 )
 

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -71,6 +71,23 @@ class EnvCfg(BaseSettings):
     # the mods channel with repeated alerts for the same user.
     ACELERADO_ANTISPAM_ALERT_COOLDOWN_SECONDS: int = 600
 
+    # ------------------------------------------------------------------
+    # Monthly challenges (issue #37) — Phase 1 toggles
+    # Disabled by default until the announce channel is wired up.
+    # ------------------------------------------------------------------
+    ACELERADO_CHALLENGES_ENABLED: bool = False
+    # GitHub repo holding the monthly problem folders.
+    ACELERADO_CHALLENGES_REPO: str = "wainejr/acelerado-desafios"
+    # Channel ID where new challenges are announced. Separate from the
+    # YouTube announce channel so video posts and challenge posts can
+    # land in different topical channels.
+    DISCORD_CHALLENGES_CHANNEL_ID: int = 0
+    # Day of the month (1-28) and UTC hour the announcement step is
+    # allowed to fire. Picking after publication time avoids spamming if
+    # the maintainer pushes the spec at midnight.
+    ACELERADO_CHALLENGES_ANNOUNCE_DAY: int = 1
+    ACELERADO_CHALLENGES_ANNOUNCE_HOUR_UTC: int = 12
+
 
 def get_env() -> EnvCfg:
     """Return the merged :class:`EnvCfg`, with ``config.json`` applied on top.

--- a/acelerado/metrics.py
+++ b/acelerado/metrics.py
@@ -39,6 +39,7 @@ class TimelineEntry(BaseModel):
 class Metrics(BaseModel):
     videos_announced: list[TimelineEntry] = Field(default_factory=list)
     members_synced: list[TimelineEntry] = Field(default_factory=list)
+    challenges_announced: list[TimelineEntry] = Field(default_factory=list)
     errors: list[TimelineEntry] = Field(default_factory=list)
     last_successful_tick: datetime | None = None
 

--- a/acelerado/review.py
+++ b/acelerado/review.py
@@ -1,18 +1,19 @@
-"""Weekly summary + apoiadores-stale report — both posted to a private
-review channel for human approval before any public action.
+"""Editorial review primitives + weekly summary / stale-apoiadores reports.
 
 Design split:
 - **Builders** (``build_weekly_summary_text``, ``find_stale_apoiadores``)
   are pure / easy to test offline. They take data and return strings or
   member lists.
 - **Posters** (``post_weekly_summary_draft``, ``post_stale_report``)
-  are the async coroutines the bot's scheduled tasks call. They build,
-  post, and (for the weekly summary) attach a ``WeeklySummaryView`` for
-  human approval.
+  are the async coroutines the bot's scheduled tasks / admin slashes
+  call. They build, post, and (for any draft that needs approval)
+  attach an :class:`EditableDraftView` for human review.
+- **View** (:class:`EditableDraftView`) is the generic 3-button
+  Aprovar / Editar / Descartar surface — used by the weekly summary and
+  the monthly-challenge results draft (issue #37 Phase 3).
 
-The ``WeeklySummaryView`` is non-persistent (24h timeout); if the bot
-restarts mid-review, the buttons go dead — admins can re-trigger via
-``/preview-summary``.
+The view is non-persistent (24h timeout); if the bot restarts
+mid-review, the buttons go dead and the operator must re-trigger.
 """
 
 from __future__ import annotations
@@ -123,7 +124,7 @@ def format_stale_report(members: list[discord.Member]) -> str:
 # ---------------------------------------------------------------------------
 
 
-class _EditModal(ui.Modal, title="Editar resumo"):
+class _EditModal(ui.Modal):
     new_text: ui.TextInput = ui.TextInput(
         label="Texto",
         style=discord.TextStyle.paragraph,
@@ -131,8 +132,8 @@ class _EditModal(ui.Modal, title="Editar resumo"):
         max_length=3500,
     )
 
-    def __init__(self, parent: WeeklySummaryView) -> None:
-        super().__init__()
+    def __init__(self, parent: EditableDraftView, modal_title: str = "Editar texto") -> None:
+        super().__init__(title=modal_title)
         self.parent = parent
         self.new_text.default = parent.draft_text
 
@@ -144,13 +145,26 @@ class _EditModal(ui.Modal, title="Editar resumo"):
         await interaction.response.defer()
 
 
-class WeeklySummaryView(ui.View):
-    """Three-button view shown alongside the draft summary."""
+class EditableDraftView(ui.View):
+    """Generic Aprovar / Editar / Descartar surface for any review draft.
 
-    def __init__(self, draft_text: str, announce_channel_id: int) -> None:
+    ``draft_text`` is shown verbatim and editable via the modal.
+    ``target_channel_id`` is where the approved draft is sent. The
+    modal title is configurable so the surface can read sensibly for
+    different drafts (resumo semanal, resultados do desafio, …).
+    """
+
+    def __init__(
+        self,
+        draft_text: str,
+        target_channel_id: int,
+        *,
+        modal_title: str = "Editar texto",
+    ) -> None:
         super().__init__(timeout=24 * 60 * 60)  # 24h
         self.draft_text = draft_text
-        self.announce_channel_id = announce_channel_id
+        self.target_channel_id = target_channel_id
+        self.modal_title = modal_title
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         # Only mods (manage_messages) can act. discord.py auto-replies if False.
@@ -170,13 +184,13 @@ class WeeklySummaryView(ui.View):
         _button: ui.Button,
     ) -> None:
         bot = cast(commands.Bot, interaction.client)
-        announce_channel = bot.get_channel(self.announce_channel_id)
-        if not isinstance(announce_channel, discord.abc.Messageable):
+        target_channel = bot.get_channel(self.target_channel_id)
+        if not isinstance(target_channel, discord.abc.Messageable):
             await interaction.response.send_message(
-                "⚠️ Canal de anúncios não acessível.", ephemeral=True
+                "⚠️ Canal de destino não acessível.", ephemeral=True
             )
             return
-        await announce_channel.send(self.draft_text)
+        await target_channel.send(self.draft_text)
         if interaction.message is not None:
             await interaction.message.edit(content=f"✅ APROVADO\n\n{self.draft_text}", view=None)
         await interaction.response.send_message("Postado!", ephemeral=True)
@@ -188,7 +202,7 @@ class WeeklySummaryView(ui.View):
         interaction: discord.Interaction,
         _button: ui.Button,
     ) -> None:
-        await interaction.response.send_modal(_EditModal(self))
+        await interaction.response.send_modal(_EditModal(self, self.modal_title))
 
     @ui.button(label="🚫 Descartar", style=discord.ButtonStyle.danger)
     async def discard(
@@ -231,7 +245,11 @@ async def post_weekly_summary_draft(bot: commands.Bot) -> str:
             logger.warning(f"Could not fetch video {vid} for summary: {exc}")
 
     draft = build_weekly_summary_text(full_videos)
-    view = WeeklySummaryView(draft, cfg.DISCORD_ANNOUNCE_CHANNEL_ID)
+    view = EditableDraftView(
+        draft,
+        cfg.DISCORD_ANNOUNCE_CHANNEL_ID,
+        modal_title="Editar resumo",
+    )
     await review_channel.send(content=draft, view=view)
     return "✅ Rascunho postado no canal de review."
 

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -14,6 +14,7 @@ To add a new command:
 
 import logging
 import re
+from typing import cast
 
 import discord
 from discord import app_commands
@@ -187,11 +188,18 @@ async def cmd_godbolt(
     await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
-@app_commands.command(
-    name="desafio",
-    description="Mostra o desafio de performance ativo do mês",
-)
-async def cmd_desafio(interaction: discord.Interaction) -> None:
+# ---------------------------------------------------------------------------
+# /desafio group — issue #37 Phases 1–3
+#
+# Built as a group so the surface is ``/desafio status``, ``/desafio
+# resultados <slug>``, etc. Same pattern as ``/config``: the group lives
+# inside :func:`_build_desafio_group` because discord.py binds groups to
+# a tree at add time and barfs on re-registration.
+# ---------------------------------------------------------------------------
+
+
+async def _render_status(interaction: discord.Interaction) -> None:
+    """Body of ``/desafio status`` — the active challenge view."""
     from datetime import UTC, datetime
 
     from acelerado.challenges import announce as challenge_announce
@@ -260,6 +268,159 @@ async def cmd_desafio(interaction: discord.Interaction) -> None:
         inline=False,
     )
     await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+def _build_desafio_group() -> app_commands.Group:
+    """Build a fresh ``/desafio`` group bound to a single tree."""
+    from discord.ext import commands
+
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges import results as challenge_results
+    from acelerado.challenges.state import ChallengesState
+    from acelerado.env import get_env
+    from acelerado.review import EditableDraftView
+
+    group = app_commands.Group(
+        name="desafio",
+        description="Desafios mensais de performance",
+    )
+
+    @group.command(name="status", description="Mostra o desafio ativo do mês")
+    async def cmd_status(interaction: discord.Interaction) -> None:
+        await _render_status(interaction)
+
+    @group.command(
+        name="resultados",
+        description="(admin) Posta o draft de resultados do desafio no canal de review",
+    )
+    @app_commands.describe(slug="Slug do desafio (ex: 2026-05-deblur)")
+    @app_commands.default_permissions(administrator=True)
+    async def cmd_resultados(interaction: discord.Interaction, slug: str) -> None:
+        cfg = get_env()
+        if not cfg.DISCORD_REVIEW_CHANNEL_ID:
+            await interaction.response.send_message(
+                "⚠️ DISCORD_REVIEW_CHANNEL_ID não configurado.",
+                ephemeral=True,
+            )
+            return
+        if not cfg.DISCORD_CHALLENGES_CHANNEL_ID:
+            await interaction.response.send_message(
+                "⚠️ DISCORD_CHALLENGES_CHANNEL_ID não configurado — sem destino pra postar.",
+                ephemeral=True,
+            )
+            return
+
+        bot = cast(commands.Bot, interaction.client)
+        review_channel = bot.get_channel(cfg.DISCORD_REVIEW_CHANNEL_ID)
+        if not isinstance(review_channel, discord.abc.Messageable):
+            await interaction.response.send_message(
+                "⚠️ Canal de review não acessível.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            results = await challenge_github.fetch_results(
+                cfg.ACELERADO_CHALLENGES_REPO,
+                slug,
+            )
+        except challenge_github.GitHubError as exc:
+            await interaction.followup.send(
+                f"⚠️ Erro buscando results.json: `{exc}`",
+                ephemeral=True,
+            )
+            return
+
+        if results is None:
+            await interaction.followup.send(
+                f"📭 `{slug}/results.json` não existe no repo ainda.",
+                ephemeral=True,
+            )
+            return
+
+        draft = challenge_results.render_results_post(results)
+        view = EditableDraftView(
+            draft,
+            cfg.DISCORD_CHALLENGES_CHANNEL_ID,
+            modal_title="Editar resultados",
+        )
+        await review_channel.send(content=draft, view=view)
+
+        ChallengesState().mark_results_posted(slug)
+        await interaction.followup.send(
+            f"✅ Draft de **{slug}** postado em <#{cfg.DISCORD_REVIEW_CHANNEL_ID}>.",
+            ephemeral=True,
+        )
+
+    @group.command(
+        name="resultados-skip",
+        description="(admin) Para de cobrar resultados desse desafio",
+    )
+    @app_commands.describe(slug="Slug do desafio (ex: 2026-05-deblur)")
+    @app_commands.default_permissions(administrator=True)
+    async def cmd_resultados_skip(interaction: discord.Interaction, slug: str) -> None:
+        ChallengesState().mark_results_dismissed(slug)
+        await interaction.response.send_message(
+            f"✅ Reminders de **{slug}** silenciados.", ephemeral=True
+        )
+
+    @group.command(
+        name="historico",
+        description="Top-3 dos desafios passados (cache de 6h)",
+    )
+    async def cmd_historico(interaction: discord.Interaction) -> None:
+        cfg = get_env()
+        if not cfg.ACELERADO_CHALLENGES_ENABLED:
+            await interaction.response.send_message(
+                "⚠️ Desafios mensais ainda não estão habilitados.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            history, fetched_at = await challenge_github.get_cached_history(
+                cfg.ACELERADO_CHALLENGES_REPO,
+            )
+        except challenge_github.GitHubError as exc:
+            await interaction.followup.send(
+                f"⚠️ Erro lendo o histórico: `{exc}`",
+                ephemeral=True,
+            )
+            return
+
+        if not history:
+            await interaction.followup.send(
+                "📭 Ainda não há resultados publicados.", ephemeral=True
+            )
+            return
+
+        embed = discord.Embed(
+            title="🏁 Histórico de desafios",
+            color=discord.Color.dark_gold(),
+        )
+        for results in history:
+            top3 = [e for e in results.ranking if e.rank <= 3]
+            if top3:
+                lines = []
+                for entry in top3:
+                    primary_str = challenge_results.format_metric_value(
+                        results.primary_metric,
+                        entry.metrics.get(results.primary_metric, "—"),
+                    )
+                    lines.append(f"{entry.rank}º @{entry.user} — {primary_str}")
+                value = "\n".join(lines)
+            else:
+                value = "_sem submissões válidas_"
+            embed.add_field(
+                name=f"{results.slug} ({results.primary_metric})",
+                value=value,
+                inline=False,
+            )
+        embed.set_footer(text=f"Última atualização: {fetched_at.strftime('%Y-%m-%d %H:%M UTC')}")
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    return group
 
 
 @app_commands.command(name="report", description="Reportar uma mensagem aos mods")
@@ -468,5 +629,5 @@ def register_commands(
     tree.add_command(cmd_preview_summary, guild=guild)
     tree.add_command(cmd_preview_stale, guild=guild)
     tree.add_command(cmd_godbolt, guild=guild)
-    tree.add_command(cmd_desafio, guild=guild)
+    tree.add_command(_build_desafio_group(), guild=guild)
     tree.add_command(_build_config_group(), guild=guild)

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -227,6 +227,18 @@ async def cmd_desafio(interaction: discord.Interaction) -> None:
         )
         return
 
+    # Submission count is best-effort — a flaky GitHub call shouldn't
+    # tank the whole reply. We surface "indisponível" inline instead.
+    try:
+        open_prs = await challenge_github.count_open_submissions(
+            cfg.ACELERADO_CHALLENGES_REPO,
+        )
+        submissions_line = f"📊 **{open_prs}** submissões abertas"
+    except challenge_github.GitHubError:
+        submissions_line = "📊 Submissões: indisponível no momento"
+
+    pr_url = f"https://github.com/{cfg.ACELERADO_CHALLENGES_REPO}/pulls"
+
     embed = discord.Embed(
         title=f"🏁 Desafio de {spec.month} — {spec.title}",
         description=challenge_announce.render_short_status(spec),
@@ -242,6 +254,11 @@ async def cmd_desafio(interaction: discord.Interaction) -> None:
             inline=False,
         )
     embed.add_field(name="Enunciado", value=spec.site_url, inline=False)
+    embed.add_field(
+        name="Submissões",
+        value=f"{submissions_line} — [ver PRs]({pr_url})",
+        inline=False,
+    )
     await interaction.followup.send(embed=embed, ephemeral=True)
 
 

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -187,6 +187,64 @@ async def cmd_godbolt(
     await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
+@app_commands.command(
+    name="desafio",
+    description="Mostra o desafio de performance ativo do mês",
+)
+async def cmd_desafio(interaction: discord.Interaction) -> None:
+    from datetime import UTC, datetime
+
+    from acelerado.challenges import announce as challenge_announce
+    from acelerado.challenges import github as challenge_github
+    from acelerado.env import get_env
+
+    cfg = get_env()
+    if not cfg.ACELERADO_CHALLENGES_ENABLED:
+        await interaction.response.send_message(
+            "⚠️ Desafios mensais ainda não estão habilitados neste servidor.",
+            ephemeral=True,
+        )
+        return
+
+    await interaction.response.defer(ephemeral=True, thinking=True)
+    month = datetime.now(UTC).strftime("%Y-%m")
+    try:
+        spec = await challenge_github.find_current_spec(
+            cfg.ACELERADO_CHALLENGES_REPO,
+            month,
+        )
+    except challenge_github.GitHubError as exc:
+        await interaction.followup.send(
+            f"⚠️ Não consegui falar com o GitHub: `{exc}`",
+            ephemeral=True,
+        )
+        return
+
+    if spec is None:
+        await interaction.followup.send(
+            f"📭 Nenhum desafio publicado para **{month}** ainda — fica de olho.",
+            ephemeral=True,
+        )
+        return
+
+    embed = discord.Embed(
+        title=f"🏁 Desafio de {spec.month} — {spec.title}",
+        description=challenge_announce.render_short_status(spec),
+        url=spec.site_url,
+        color=discord.Color.green(),
+    )
+    if spec.caps:
+        embed.add_field(
+            name="Limites",
+            value="\n".join(
+                f"• {challenge_announce.format_cap(k, v)}" for k, v in spec.caps.items()
+            ),
+            inline=False,
+        )
+    embed.add_field(name="Enunciado", value=spec.site_url, inline=False)
+    await interaction.followup.send(embed=embed, ephemeral=True)
+
+
 @app_commands.command(name="report", description="Reportar uma mensagem aos mods")
 @app_commands.describe(
     message_link="Link da mensagem (clique-direito → Copy Message Link)",
@@ -257,6 +315,7 @@ _CHANNEL_KEY_CHOICES = [
     app_commands.Choice(name="welcome", value="DISCORD_WELCOME_CHANNEL_ID"),
     app_commands.Choice(name="mods", value="DISCORD_MODS_CHANNEL_ID"),
     app_commands.Choice(name="review", value="DISCORD_REVIEW_CHANNEL_ID"),
+    app_commands.Choice(name="challenges", value="DISCORD_CHALLENGES_CHANNEL_ID"),
 ]
 
 # Non-channel, non-secret editable keys exposed via /config set + unset.
@@ -265,6 +324,8 @@ _PLAIN_KEY_CHOICES = [
     app_commands.Choice(name="auto-thread", value="ACELERADO_AUTO_THREAD"),
     app_commands.Choice(name="live-reminder-min", value="ACELERADO_LIVE_REMINDER_MINUTES"),
     app_commands.Choice(name="apoiadores-whitelist", value="ACELERADO_APOIADORES_WHITELIST"),
+    app_commands.Choice(name="challenges-enabled", value="ACELERADO_CHALLENGES_ENABLED"),
+    app_commands.Choice(name="challenges-repo", value="ACELERADO_CHALLENGES_REPO"),
 ]
 
 # Union for /config unset (covers every editable key).
@@ -390,4 +451,5 @@ def register_commands(
     tree.add_command(cmd_preview_summary, guild=guild)
     tree.add_command(cmd_preview_stale, guild=guild)
     tree.add_command(cmd_godbolt, guild=guild)
+    tree.add_command(cmd_desafio, guild=guild)
     tree.add_command(_build_config_group(), guild=guild)

--- a/acelerado/state.py
+++ b/acelerado/state.py
@@ -7,6 +7,9 @@ import discord
 from discord.ext import commands
 
 from acelerado import metrics, youtube
+from acelerado.challenges import announce as challenge_announce
+from acelerado.challenges import github as challenge_github
+from acelerado.challenges.state import ChallengesState
 from acelerado.env import get_env
 from acelerado.error_reporter import ErrorReporter
 from acelerado.review import parse_username_whitelist
@@ -30,6 +33,7 @@ class AceleradoState:
         # "Long enough ago that the first warning isn't rate-limited."
         self.last_msg_expiry = datetime.now(UTC) - timedelta(days=7)
         self.error_reporter = ErrorReporter(lambda: self.channel_log)
+        self.challenges = ChallengesState()
 
         # Channel validation only — cheap cache lookup, no I/O. Network /
         # OAuth-triggering work happens in `warm_up`.
@@ -57,6 +61,16 @@ class AceleradoState:
         return cast(
             "discord.abc.Messageable | None",
             self.bot.get_channel(get_env().DISCORD_ANNOUNCE_CHANNEL_ID),
+        )
+
+    @property
+    def channel_challenges(self) -> discord.abc.Messageable | None:
+        cid = get_env().DISCORD_CHALLENGES_CHANNEL_ID
+        if not cid:
+            return None
+        return cast(
+            "discord.abc.Messageable | None",
+            self.bot.get_channel(cid),
         )
 
     # ------------------------------------------------------------------
@@ -282,6 +296,53 @@ class AceleradoState:
                     f"({youtube.video_state_flags(video)})"
                 )
 
+    # ------------------------------------------------------------------
+    # Monthly challenge announcement (issue #37, Phase 1)
+    # ------------------------------------------------------------------
+
+    async def _announce_new_challenge(self) -> None:
+        """If today's the announce day and no post yet, announce the active challenge.
+
+        Idempotent via :class:`ChallengesState` — the slug (not the
+        month) is the key, so a folder rename mid-month re-announces
+        rather than silently skipping.
+        """
+        cfg = get_env()
+        if not cfg.ACELERADO_CHALLENGES_ENABLED:
+            return
+
+        now = datetime.now(UTC)
+        if now.day != cfg.ACELERADO_CHALLENGES_ANNOUNCE_DAY:
+            return
+        if now.hour < cfg.ACELERADO_CHALLENGES_ANNOUNCE_HOUR_UTC:
+            return
+
+        channel = self.channel_challenges
+        if channel is None:
+            logger.warning(
+                "Challenges enabled but DISCORD_CHALLENGES_CHANNEL_ID not configured; "
+                "skipping announcement"
+            )
+            return
+
+        month = now.strftime("%Y-%m")
+        spec = await challenge_github.find_current_spec(
+            cfg.ACELERADO_CHALLENGES_REPO,
+            month,
+        )
+        if spec is None:
+            logger.info(f"No challenge folder found for {month}; skipping")
+            return
+
+        if self.challenges.is_announced(spec.slug):
+            return
+
+        msg = challenge_announce.render_announcement(spec)
+        await channel.send(msg)
+        self.challenges.mark_announced(spec.slug)
+        metrics.increment("challenges_announced", context=spec.slug)
+        logger.info(f"Announced challenge {spec.slug}")
+
     async def event_loop(self) -> None:
         logger.info("Started event loop...")
 
@@ -290,6 +351,7 @@ class AceleradoState:
             ("expiration", self.check_expiration),
             ("upcoming_lives", self._check_upcoming_lives),
             ("videos", self._pub_new_videos),
+            ("challenge_announce", self._announce_new_challenge),
         ]
         for name, step in steps:
             try:

--- a/acelerado/state.py
+++ b/acelerado/state.py
@@ -343,6 +343,47 @@ class AceleradoState:
         metrics.increment("challenges_announced", context=spec.slug)
         logger.info(f"Announced challenge {spec.slug}")
 
+    async def _remind_pending_results(self) -> None:
+        """Nudge the operator (in the log channel) to post results for past challenges.
+
+        A "ripe" slug is one whose ``YYYY-MM`` is strictly before the
+        current month and which is neither posted nor dismissed in the
+        challenges state. We rate-limit reminders to once per 24h per
+        slug so the log channel doesn't get spammy on a 5-minute tick.
+        """
+        cfg = get_env()
+        if not cfg.ACELERADO_CHALLENGES_ENABLED:
+            return
+
+        log_channel = self.channel_log
+        if log_channel is None:
+            return
+
+        now = datetime.now(UTC)
+        current_month = now.strftime("%Y-%m")
+
+        try:
+            slugs = await challenge_github.list_challenge_slugs(
+                cfg.ACELERADO_CHALLENGES_REPO,
+            )
+        except challenge_github.GitHubError as exc:
+            logger.warning(f"Could not list challenges for reminder: {exc}")
+            return
+
+        for slug in slugs:
+            month = challenge_github.slug_month(slug)
+            if month is None or month >= current_month:
+                continue  # active or future month — no nudge yet
+            if not self.challenges.should_remind(slug):
+                continue
+            await log_channel.send(
+                f"📋 Resultados de **{slug}** pendentes. "
+                f"Use `/desafio resultados {slug}` quando rodar os benchmarks, "
+                f"ou `/desafio resultados-skip {slug}` pra parar de avisar."
+            )
+            self.challenges.mark_reminded(slug)
+            logger.info(f"Posted results reminder for {slug}")
+
     async def event_loop(self) -> None:
         logger.info("Started event loop...")
 
@@ -352,6 +393,7 @@ class AceleradoState:
             ("upcoming_lives", self._check_upcoming_lives),
             ("videos", self._pub_new_videos),
             ("challenge_announce", self._announce_new_challenge),
+            ("challenge_results_reminder", self._remind_pending_results),
         ]
         for name, step in steps:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pydantic-settings>=2.5",
     "typer>=0.12",
     "textual>=0.80",
+    "httpx>=0.28.1",
 ]
 
 [project.scripts]
@@ -32,6 +33,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=5",
     "mypy>=1.11",
+    "respx>=0.23.1",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_challenges_announce.py
+++ b/tests/test_challenges_announce.py
@@ -1,0 +1,76 @@
+"""Tests for the announcement renderer."""
+
+from __future__ import annotations
+
+from acelerado.challenges.announce import (
+    format_cap,
+    render_announcement,
+    render_short_status,
+)
+from acelerado.challenges.spec import load_spec
+
+
+def _spec(**overrides):
+    base = {
+        "name": "deblur",
+        "title": "arrumando autofoco",
+        "month": "2026-05",
+        "primary_metric": "psnr_mean_db",
+        "direction": "max",
+        "caps": {"time_ms_per_image": 200, "peak_rss_mb": 64},
+    }
+    base.update(overrides)
+    return load_spec(base)
+
+
+def test_render_psnr_max_uses_metric_specific_copy():
+    msg = render_announcement(_spec())
+    assert "Maximizar **PSNR médio**" in msg
+    assert "@everyone" in msg
+    assert "2026-05" in msg
+    assert "arrumando autofoco" in msg
+    assert "https://wainejr.github.io/acelerado-desafios/desafios/2026-05-deblur/" in msg
+
+
+def test_render_includes_caps_section():
+    msg = render_announcement(_spec())
+    assert "Limites:" in msg
+    assert "200 ms" in msg
+    assert "64 MB" in msg
+
+
+def test_render_unknown_metric_falls_back_to_generic_copy():
+    spec = _spec(primary_metric="weirdness", direction="min", caps={})
+    msg = render_announcement(spec)
+    assert "Minimizar" in msg
+    assert "weirdness" in msg
+    # No caps line when caps dict is empty.
+    assert "Limites:" not in msg
+
+
+def test_render_time_min_metric():
+    spec = _spec(primary_metric="time_ms", direction="min", caps={"time_ms": 1000})
+    msg = render_announcement(spec)
+    assert "tempo de execução" in msg
+    # ``time_ms`` cap should NOT carry the per-imagem suffix.
+    assert "1000 ms\n" in msg or "1000 ms\n" in msg + "\n"
+    assert "1000 ms por imagem" not in msg
+
+
+def test_format_cap_known_keys():
+    assert format_cap("time_ms", 100) == "⏱ 100 ms"
+    assert format_cap("time_ms_per_image", 200) == "⏱ 200 ms por imagem"
+    assert format_cap("peak_rss_mb", 64) == "💾 64 MB de RAM"
+    assert format_cap("disk_write_mb", 10) == "📝 10 MB de escrita em disco"
+    assert format_cap("binary_size_bytes", 2048) == "📦 2048 bytes (binário)"
+    assert format_cap("code_size_bytes", 512) == "📜 512 bytes (código-fonte)"
+
+
+def test_format_cap_unknown_key_falls_back():
+    assert format_cap("custom_metric", 42) == "custom_metric: 42"
+
+
+def test_render_short_status_one_liner():
+    line = render_short_status(_spec())
+    assert line.startswith("**2026-05 — arrumando autofoco**")
+    assert "PSNR" in line

--- a/tests/test_challenges_github.py
+++ b/tests/test_challenges_github.py
@@ -1,0 +1,133 @@
+"""Tests for the async GitHub client.
+
+Network calls are mocked at the httpx transport layer via ``respx``,
+so we exercise the real ``httpx.AsyncClient`` code path (headers,
+timeouts, error handling) without hitting api.github.com.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from acelerado.challenges import github as gh
+
+REPO = "wainejr/acelerado-desafios"
+SPEC_PAYLOAD = {
+    "name": "deblur",
+    "title": "arrumando autofoco",
+    "month": "2026-05",
+    "primary_metric": "psnr_mean_db",
+    "direction": "max",
+    "caps": {"time_ms_per_image": 200, "peak_rss_mb": 64},
+}
+
+
+def _contents_payload() -> list[dict[str, str]]:
+    return [
+        {"name": "README.md", "type": "file"},
+        {"name": "LICENSE", "type": "file"},
+        {"name": "2026-05-deblur", "type": "dir"},
+        {"name": "2026-04-mandelbrot", "type": "dir"},
+        {"name": "scripts", "type": "dir"},  # not YYYY-MM-prefixed
+    ]
+
+
+@respx.mock
+async def test_list_challenge_slugs_filters_to_dated_dirs():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=_contents_payload())
+    )
+    slugs = await gh.list_challenge_slugs(REPO)
+    assert slugs == ["2026-04-mandelbrot", "2026-05-deblur"]
+
+
+@respx.mock
+async def test_list_challenge_slugs_raises_on_http_error():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(404, text="not found")
+    )
+    with pytest.raises(gh.GitHubError, match="404"):
+        await gh.list_challenge_slugs(REPO)
+
+
+@respx.mock
+async def test_list_challenge_slugs_raises_on_non_list_payload():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json={"unexpected": "shape"})
+    )
+    with pytest.raises(gh.GitHubError, match="expected list"):
+        await gh.list_challenge_slugs(REPO)
+
+
+@respx.mock
+async def test_fetch_spec_loads_from_raw_endpoint():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/spec.json"
+    respx.get(url).mock(return_value=httpx.Response(200, json=SPEC_PAYLOAD))
+
+    spec = await gh.fetch_spec(REPO, "2026-05-deblur")
+    assert spec.name == "deblur"
+    assert spec.primary_metric == "psnr_mean_db"
+
+
+@respx.mock
+async def test_fetch_spec_propagates_http_errors():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/spec.json"
+    respx.get(url).mock(return_value=httpx.Response(500, text="internal"))
+    with pytest.raises(gh.GitHubError, match="500"):
+        await gh.fetch_spec(REPO, "2026-05-deblur")
+
+
+@respx.mock
+async def test_find_current_spec_picks_matching_month():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=_contents_payload())
+    )
+    respx.get(f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/spec.json").mock(
+        return_value=httpx.Response(200, json=SPEC_PAYLOAD)
+    )
+
+    spec = await gh.find_current_spec(REPO, "2026-05")
+    assert spec is not None
+    assert spec.slug == "2026-05-deblur"
+
+
+@respx.mock
+async def test_find_current_spec_returns_none_when_no_match():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=_contents_payload())
+    )
+    spec = await gh.find_current_spec(REPO, "2026-06")
+    assert spec is None
+
+
+@respx.mock
+async def test_token_added_as_authorization_header(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+    route = respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    await gh.list_challenge_slugs(REPO)
+    sent = route.calls.last.request
+    assert sent.headers["Authorization"] == "Bearer secret-token"
+
+
+@respx.mock
+async def test_no_token_means_no_authorization_header(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    route = respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    await gh.list_challenge_slugs(REPO)
+    assert "Authorization" not in route.calls.last.request.headers
+
+
+def test_slug_month_extracts_prefix():
+    assert gh.slug_month("2026-05-deblur") == "2026-05"
+    assert gh.slug_month("2026-12-foo-bar") == "2026-12"
+
+
+def test_slug_month_returns_none_for_invalid():
+    assert gh.slug_month("scripts") is None
+    assert gh.slug_month("2026-13-bad-month") is None

--- a/tests/test_challenges_github.py
+++ b/tests/test_challenges_github.py
@@ -123,6 +123,47 @@ async def test_no_token_means_no_authorization_header(monkeypatch):
     assert "Authorization" not in route.calls.last.request.headers
 
 
+@respx.mock
+async def test_count_open_submissions_returns_length_of_pr_list():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"number": 1, "user": {"login": "alice"}},
+                {"number": 2, "user": {"login": "bob"}},
+                {"number": 3, "user": {"login": "carol"}},
+            ],
+        )
+    )
+    assert await gh.count_open_submissions(REPO) == 3
+
+
+@respx.mock
+async def test_count_open_submissions_zero_when_empty():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    assert await gh.count_open_submissions(REPO) == 0
+
+
+@respx.mock
+async def test_count_open_submissions_raises_on_http_error():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    with pytest.raises(gh.GitHubError, match="500"):
+        await gh.count_open_submissions(REPO)
+
+
+@respx.mock
+async def test_count_open_submissions_raises_on_non_list_payload():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(200, json={"unexpected": "shape"})
+    )
+    with pytest.raises(gh.GitHubError, match="expected list"):
+        await gh.count_open_submissions(REPO)
+
+
 def test_slug_month_extracts_prefix():
     assert gh.slug_month("2026-05-deblur") == "2026-05"
     assert gh.slug_month("2026-12-foo-bar") == "2026-12"

--- a/tests/test_challenges_github.py
+++ b/tests/test_challenges_github.py
@@ -164,6 +164,128 @@ async def test_count_open_submissions_raises_on_non_list_payload():
         await gh.count_open_submissions(REPO)
 
 
+# ---------------------------------------------------------------------------
+# Phase 3 — fetch_results / list_past_results / get_cached_history
+# ---------------------------------------------------------------------------
+
+
+RESULTS_PAYLOAD = {
+    "slug": "2026-05-deblur",
+    "primary_metric": "psnr_mean_db",
+    "direction": "max",
+    "ranking": [{"rank": 1, "user": "alice", "metrics": {"psnr_mean_db": 41.2}}],
+}
+
+
+@respx.mock
+async def test_fetch_results_returns_parsed_payload():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    respx.get(url).mock(return_value=httpx.Response(200, json=RESULTS_PAYLOAD))
+
+    results = await gh.fetch_results(REPO, "2026-05-deblur")
+    assert results is not None
+    assert results.slug == "2026-05-deblur"
+    assert results.ranking[0].user == "alice"
+
+
+@respx.mock
+async def test_fetch_results_returns_none_on_404():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-06-foo/results.json"
+    respx.get(url).mock(return_value=httpx.Response(404, text="not found"))
+    assert await gh.fetch_results(REPO, "2026-06-foo") is None
+
+
+@respx.mock
+async def test_fetch_results_raises_on_other_http_errors():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    respx.get(url).mock(return_value=httpx.Response(500, text="boom"))
+    with pytest.raises(gh.GitHubError, match="500"):
+        await gh.fetch_results(REPO, "2026-05-deblur")
+
+
+@respx.mock
+async def test_list_past_results_collects_only_existing_files():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=_contents_payload())
+    )
+    # 2026-05-deblur has results, 2026-04-mandelbrot doesn't.
+    respx.get(f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json").mock(
+        return_value=httpx.Response(200, json=RESULTS_PAYLOAD)
+    )
+    respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-04-mandelbrot/results.json"
+    ).mock(return_value=httpx.Response(404, text="not yet"))
+
+    history = await gh.list_past_results(REPO)
+    assert len(history) == 1
+    assert history[0].slug == "2026-05-deblur"
+
+
+@respx.mock
+async def test_list_past_results_orders_most_recent_first():
+    contents = [
+        {"name": "2026-04-mandelbrot", "type": "dir"},
+        {"name": "2026-05-deblur", "type": "dir"},
+    ]
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=contents)
+    )
+    payload_05 = dict(RESULTS_PAYLOAD)
+    payload_04 = {
+        "slug": "2026-04-mandelbrot",
+        "primary_metric": "time_ms",
+        "direction": "min",
+        "ranking": [],
+    }
+    respx.get(f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json").mock(
+        return_value=httpx.Response(200, json=payload_05)
+    )
+    respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-04-mandelbrot/results.json"
+    ).mock(return_value=httpx.Response(200, json=payload_04))
+
+    history = await gh.list_past_results(REPO)
+    assert [r.slug for r in history] == ["2026-05-deblur", "2026-04-mandelbrot"]
+
+
+@respx.mock
+async def test_get_cached_history_returns_fresh_then_cached():
+    from datetime import timedelta
+
+    gh.clear_history_cache()
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=[{"name": "2026-05-deblur", "type": "dir"}])
+    )
+    raw_route = respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    ).mock(return_value=httpx.Response(200, json=RESULTS_PAYLOAD))
+
+    first, t1 = await gh.get_cached_history(REPO, ttl=timedelta(hours=6))
+    second, t2 = await gh.get_cached_history(REPO, ttl=timedelta(hours=6))
+    assert [r.slug for r in first] == [r.slug for r in second]
+    # Cache returned same timestamp, didn't refetch raw.
+    assert t1 == t2
+    assert raw_route.call_count == 1
+
+
+@respx.mock
+async def test_get_cached_history_refreshes_after_ttl():
+    from datetime import timedelta
+
+    gh.clear_history_cache()
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=[{"name": "2026-05-deblur", "type": "dir"}])
+    )
+    raw_route = respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    ).mock(return_value=httpx.Response(200, json=RESULTS_PAYLOAD))
+
+    await gh.get_cached_history(REPO, ttl=timedelta(seconds=0))
+    await gh.get_cached_history(REPO, ttl=timedelta(seconds=0))
+    # zero TTL means every call is a miss.
+    assert raw_route.call_count == 2
+
+
 def test_slug_month_extracts_prefix():
     assert gh.slug_month("2026-05-deblur") == "2026-05"
     assert gh.slug_month("2026-12-foo-bar") == "2026-12"

--- a/tests/test_challenges_results.py
+++ b/tests/test_challenges_results.py
@@ -1,0 +1,189 @@
+"""Tests for ``acelerado.challenges.results`` — model + renderer."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from acelerado.challenges.results import (
+    format_metric_value,
+    load_results,
+    render_results_post,
+)
+
+PSNR_PAYLOAD = {
+    "slug": "2026-05-deblur",
+    "primary_metric": "psnr_mean_db",
+    "direction": "max",
+    "ranking": [
+        {
+            "rank": 1,
+            "user": "alice",
+            "language": "rust",
+            "metrics": {"psnr_mean_db": 41.2, "time_ms_per_image": 87, "peak_rss_mb": 38},
+        },
+        {
+            "rank": 2,
+            "user": "bob",
+            "language": "c",
+            "metrics": {"psnr_mean_db": 39.8, "time_ms_per_image": 102, "peak_rss_mb": 42},
+        },
+        {
+            "rank": 3,
+            "user": "carol",
+            "language": "python",
+            "metrics": {"psnr_mean_db": 35.5, "time_ms_per_image": 1500, "peak_rss_mb": 60},
+        },
+        {
+            "rank": 4,
+            "user": "dave",
+            "language": "go",
+            "metrics": {"psnr_mean_db": 30.1, "time_ms_per_image": 90, "peak_rss_mb": 45},
+        },
+    ],
+    "disqualified": [{"user": "eve", "reason": "estourou peak_rss_mb cap"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_load_results_parses_full_payload():
+    results = load_results(PSNR_PAYLOAD)
+    assert results.slug == "2026-05-deblur"
+    assert results.primary_metric == "psnr_mean_db"
+    assert len(results.ranking) == 4
+    assert results.ranking[0].user == "alice"
+    assert results.ranking[0].metrics["psnr_mean_db"] == 41.2
+    assert len(results.disqualified) == 1
+
+
+def test_load_results_preserves_unknown_fields():
+    payload = dict(PSNR_PAYLOAD, hardware="ryzen 9 5950x")
+    results = load_results(payload)
+    assert results.model_extra is not None
+    assert results.model_extra.get("hardware") == "ryzen 9 5950x"
+
+
+def test_load_results_rejects_missing_required():
+    bad = {k: v for k, v in PSNR_PAYLOAD.items() if k != "primary_metric"}
+    with pytest.raises(ValidationError):
+        load_results(bad)
+
+
+def test_load_results_empty_ranking_ok():
+    minimal = {"slug": "2026-06-foo", "primary_metric": "time_ms", "direction": "min"}
+    results = load_results(minimal)
+    assert results.ranking == []
+    assert results.disqualified == []
+
+
+# ---------------------------------------------------------------------------
+# format_metric_value
+# ---------------------------------------------------------------------------
+
+
+def test_format_time_ms_under_one_second():
+    assert format_metric_value("time_ms", 87) == "87 ms"
+
+
+def test_format_time_ms_seconds():
+    assert format_metric_value("time_ms", 1500) == "1.50 s"
+
+
+def test_format_time_ms_per_image_appends_per_img():
+    assert format_metric_value("time_ms_per_image", 87) == "87 ms/img"
+    assert format_metric_value("time_ms_per_image", 1500) == "1.50 s/img"
+
+
+def test_format_memory_mb():
+    assert format_metric_value("peak_rss_mb", 142) == "142 MB"
+    assert format_metric_value("disk_write_mb", 15) == "15 MB"
+
+
+def test_format_bytes_humanizes():
+    assert format_metric_value("binary_size_bytes", 312) == "312 B"
+    assert format_metric_value("binary_size_bytes", 2048) == "2.0 KB"
+    assert format_metric_value("binary_size_bytes", 2_400_000) == "2.40 MB"
+    assert format_metric_value("code_size_bytes", 312) == "312 B"
+
+
+def test_format_psnr_db():
+    assert format_metric_value("psnr_mean_db", 41.2) == "41.20 dB"
+
+
+def test_format_unknown_metric_falls_back_to_str():
+    assert format_metric_value("custom_metric", "weird-value") == "weird-value"
+
+
+def test_format_handles_non_numeric_gracefully():
+    # If results.json has a buggy value, we degrade to str() rather than raise.
+    assert format_metric_value("time_ms", "not-a-number") == "not-a-number"
+
+
+# ---------------------------------------------------------------------------
+# render_results_post
+# ---------------------------------------------------------------------------
+
+
+def test_render_includes_top3_with_podium():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "🥇" in post
+    assert "🥈" in post
+    assert "🥉" in post
+    assert "@alice" in post
+    assert "41.20 dB" in post
+
+
+def test_render_top3_has_secondary_line_with_lang_and_metrics():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    # alice's secondary: time + memory + language
+    assert "87 ms/img" in post
+    assert "38 MB" in post
+    assert "rust" in post
+
+
+def test_render_collapses_ranks_4plus_into_short_list():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "Demais participantes" in post
+    assert "@dave" in post
+
+
+def test_render_lists_disqualified_at_end():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "Desclassificados" in post
+    assert "@eve" in post
+    assert "estourou peak_rss_mb cap" in post
+
+
+def test_render_handles_empty_ranking():
+    results = load_results({"slug": "2026-06-foo", "primary_metric": "time_ms", "direction": "min"})
+    post = render_results_post(results)
+    assert "Sem submissões válidas" in post
+    assert "Desclassificados" not in post  # no DQ section when empty
+
+
+def test_render_handles_missing_secondary_metrics():
+    """Entry with only the primary metric — no secondary line should appear."""
+    payload = {
+        "slug": "2026-07-bar",
+        "primary_metric": "time_ms",
+        "direction": "min",
+        "ranking": [{"rank": 1, "user": "alice", "metrics": {"time_ms": 500}}],
+    }
+    results = load_results(payload)
+    post = render_results_post(results)
+    assert "@alice" in post
+    assert "500 ms" in post
+
+
+def test_render_includes_slug_in_header():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "2026-05-deblur" in post

--- a/tests/test_challenges_spec.py
+++ b/tests/test_challenges_spec.py
@@ -1,0 +1,73 @@
+"""Tests for ``acelerado.challenges.spec``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from acelerado.challenges.spec import load_spec, load_spec_file
+
+SAMPLE = {
+    "name": "deblur",
+    "title": "arrumando autofoco",
+    "month": "2026-05",
+    "primary_metric": "psnr_mean_db",
+    "direction": "max",
+    "caps": {"time_ms_per_image": 200, "peak_rss_mb": 64},
+    "image": {"format": "bmp24", "width": 512},
+}
+
+
+def test_load_spec_parses_known_fields():
+    spec = load_spec(SAMPLE)
+    assert spec.name == "deblur"
+    assert spec.title == "arrumando autofoco"
+    assert spec.month == "2026-05"
+    assert spec.primary_metric == "psnr_mean_db"
+    assert spec.direction == "max"
+    assert spec.caps == {"time_ms_per_image": 200, "peak_rss_mb": 64}
+
+
+def test_load_spec_preserves_unknown_fields_in_extras():
+    spec = load_spec(SAMPLE)
+    # ``image`` isn't a Spec field — extra="allow" puts it in model_extra.
+    assert spec.model_extra is not None
+    assert spec.model_extra.get("image") == {"format": "bmp24", "width": 512}
+
+
+def test_slug_combines_month_and_name():
+    spec = load_spec(SAMPLE)
+    assert spec.slug == "2026-05-deblur"
+
+
+def test_site_url_points_at_github_pages():
+    spec = load_spec(SAMPLE)
+    assert spec.site_url == "https://wainejr.github.io/acelerado-desafios/desafios/2026-05-deblur/"
+
+
+def test_load_spec_rejects_malformed_month():
+    bad = dict(SAMPLE, month="2026-13")
+    with pytest.raises(ValidationError):
+        load_spec(bad)
+
+
+def test_load_spec_rejects_missing_required_fields():
+    bad = {k: v for k, v in SAMPLE.items() if k != "primary_metric"}
+    with pytest.raises(ValidationError):
+        load_spec(bad)
+
+
+def test_load_spec_caps_optional():
+    minimal = {k: v for k, v in SAMPLE.items() if k != "caps"}
+    spec = load_spec(minimal)
+    assert spec.caps == {}
+
+
+def test_load_spec_file(tmp_path: Path):
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(SAMPLE))
+    spec = load_spec_file(path)
+    assert spec.name == "deblur"

--- a/tests/test_challenges_state.py
+++ b/tests/test_challenges_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from acelerado.challenges.state import ChallengesState
@@ -57,3 +58,90 @@ def test_non_object_root_starts_fresh(tmp_path: Path):
     path.write_text(json.dumps([1, 2, 3]))
     state = ChallengesState(path)
     assert state.raw == {}
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — results posted/dismissed + reminder rate-limit
+# ---------------------------------------------------------------------------
+
+
+def test_mark_results_posted_persists(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_results_posted("2026-05-deblur")
+
+    assert state.is_results_posted("2026-05-deblur")
+    on_disk = json.loads(path.read_text())
+    assert on_disk["results_posted"] == ["2026-05-deblur"]
+
+
+def test_mark_results_dismissed_persists(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_results_dismissed("2026-04-mandelbrot")
+
+    assert state.is_results_dismissed("2026-04-mandelbrot")
+    on_disk = json.loads(path.read_text())
+    assert on_disk["results_dismissed"] == ["2026-04-mandelbrot"]
+
+
+def test_mark_idempotent(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_results_posted("x")
+    state.mark_results_posted("x")
+    state.mark_results_dismissed("y")
+    state.mark_results_dismissed("y")
+    assert state._list("results_posted") == ["x"]
+    assert state._list("results_dismissed") == ["y"]
+
+
+def test_should_remind_true_when_never_reminded(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    assert state.should_remind("2026-05-deblur") is True
+
+
+def test_should_remind_false_when_posted(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_results_posted("2026-05-deblur")
+    assert state.should_remind("2026-05-deblur") is False
+
+
+def test_should_remind_false_when_dismissed(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_results_dismissed("2026-05-deblur")
+    assert state.should_remind("2026-05-deblur") is False
+
+
+def test_should_remind_respects_cooldown(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_reminded("2026-05-deblur")
+    # Default cooldown is 24h — fresh reminder shouldn't fire.
+    assert state.should_remind("2026-05-deblur") is False
+
+
+def test_should_remind_after_cooldown_elapsed(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    # Backdate the timestamp by 25h to simulate elapsed cooldown.
+    past = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+    state._data["last_remind_at"] = {"2026-05-deblur": past}
+    state._flush()
+    assert state.should_remind("2026-05-deblur") is True
+
+
+def test_should_remind_handles_corrupt_timestamp(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state._data["last_remind_at"] = {"2026-05-deblur": "not-a-date"}
+    # Garbled value should NOT mute the reminder forever — we just ignore it.
+    assert state.should_remind("2026-05-deblur") is True
+
+
+def test_mark_reminded_persists(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_reminded("2026-05-deblur")
+
+    on_disk = json.loads(path.read_text())
+    assert "2026-05-deblur" in on_disk["last_remind_at"]
+    # Should round-trip into a parseable datetime.
+    parsed = datetime.fromisoformat(on_disk["last_remind_at"]["2026-05-deblur"])
+    assert parsed.tzinfo is not None

--- a/tests/test_challenges_state.py
+++ b/tests/test_challenges_state.py
@@ -1,0 +1,59 @@
+"""Tests for ``acelerado.challenges.state``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from acelerado.challenges.state import ChallengesState
+
+
+def test_fresh_state_has_no_announcements(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    assert state.is_announced("2026-05-deblur") is False
+
+
+def test_mark_announced_persists_to_disk(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_announced("2026-05-deblur")
+
+    assert state.is_announced("2026-05-deblur") is True
+    on_disk = json.loads(path.read_text())
+    assert on_disk["announced"] == ["2026-05-deblur"]
+
+
+def test_mark_announced_is_idempotent(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_announced("2026-05-deblur")
+    state.mark_announced("2026-05-deblur")
+
+    on_disk = json.loads(path.read_text())
+    assert on_disk["announced"] == ["2026-05-deblur"]
+
+
+def test_state_round_trips_through_disk(tmp_path: Path):
+    path = tmp_path / "state.json"
+    a = ChallengesState(path)
+    a.mark_announced("2026-05-deblur")
+
+    b = ChallengesState(path)
+    assert b.is_announced("2026-05-deblur") is True
+
+
+def test_corrupt_file_starts_fresh(tmp_path: Path):
+    path = tmp_path / "state.json"
+    path.write_text("{not json")
+    state = ChallengesState(path)
+    assert state.is_announced("anything") is False
+    # Should still be writable after recovering.
+    state.mark_announced("2026-05-deblur")
+    assert state.is_announced("2026-05-deblur") is True
+
+
+def test_non_object_root_starts_fresh(tmp_path: Path):
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps([1, 2, 3]))
+    state = ChallengesState(path)
+    assert state.raw == {}

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -461,7 +461,11 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     async def fake_find(repo, month, token=None):
         return spec
 
+    async def fake_count(repo, token=None):
+        return 7
+
     monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+    monkeypatch.setattr(challenge_github, "count_open_submissions", fake_count)
 
     interaction = MagicMock(spec=discord.Interaction)
     interaction.response = MagicMock()
@@ -476,6 +480,55 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     assert isinstance(embed, discord.Embed)
     assert "arrumando autofoco" in (embed.title or "")
     assert embed.url == spec.site_url
+    # Submissions count + PR link landed in a dedicated field.
+    submissions_field = next((f for f in embed.fields if f.name == "Submissões"), None)
+    assert submissions_field is not None
+    assert "7" in (submissions_field.value or "")
+    assert "/pulls" in (submissions_field.value or "")
+
+
+async def test_desafio_renders_when_submission_count_fails(monkeypatch):
+    """A flaky GitHub call on ``count_open_submissions`` must not break the embed."""
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges.spec import load_spec
+    from acelerado.config import reload_settings
+    from acelerado.slash import cmd_desafio
+
+    reload_settings()
+
+    spec = load_spec(
+        {
+            "name": "deblur",
+            "title": "arrumando autofoco",
+            "month": "2026-05",
+            "primary_metric": "psnr_mean_db",
+            "direction": "max",
+            "caps": {},
+        }
+    )
+
+    async def fake_find(repo, month, token=None):
+        return spec
+
+    async def fake_count_boom(repo, token=None):
+        raise challenge_github.GitHubError("rate limited")
+
+    monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+    monkeypatch.setattr(challenge_github, "count_open_submissions", fake_count_boom)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    await cmd_desafio.callback(interaction)
+    embed = interaction.followup.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    submissions_field = next((f for f in embed.fields if f.name == "Submissões"), None)
+    assert submissions_field is not None
+    assert "indisponível" in (submissions_field.value or "")
 
 
 async def test_desafio_handles_missing_challenge(monkeypatch):

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -407,6 +407,126 @@ async def test_config_unset_reverts_to_fallback(chdir_tmp):
     assert get_settings().cfg.ACELERADO_TICK_SECONDS == 300  # back to default
 
 
+# ---------------------------------------------------------------------------
+# /desafio — Phase 1 of issue #37
+# ---------------------------------------------------------------------------
+
+
+def test_register_desafio_command():
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    cmd = tree.get_command("desafio", guild=guild)
+    assert cmd is not None
+    assert cmd.name == "desafio"
+
+
+async def test_desafio_responds_when_disabled(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
+    from acelerado.config import reload_settings
+    from acelerado.slash import cmd_desafio
+
+    reload_settings()
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    await cmd_desafio.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "não estão habilitados" in msg.lower() or "habilitados" in msg.lower()
+
+
+async def test_desafio_returns_embed_when_active(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges.spec import load_spec
+    from acelerado.config import reload_settings
+    from acelerado.slash import cmd_desafio
+
+    reload_settings()
+
+    spec = load_spec(
+        {
+            "name": "deblur",
+            "title": "arrumando autofoco",
+            "month": "2026-05",
+            "primary_metric": "psnr_mean_db",
+            "direction": "max",
+            "caps": {"time_ms_per_image": 200, "peak_rss_mb": 64},
+        }
+    )
+
+    async def fake_find(repo, month, token=None):
+        return spec
+
+    monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    await cmd_desafio.callback(interaction)
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    embed = interaction.followup.send.await_args.kwargs.get("embed")
+    assert isinstance(embed, discord.Embed)
+    assert "arrumando autofoco" in (embed.title or "")
+    assert embed.url == spec.site_url
+
+
+async def test_desafio_handles_missing_challenge(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.config import reload_settings
+    from acelerado.slash import cmd_desafio
+
+    reload_settings()
+
+    async def fake_find(repo, month, token=None):
+        return None
+
+    monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    await cmd_desafio.callback(interaction)
+    msg = interaction.followup.send.await_args.args[0]
+    assert "Nenhum desafio" in msg
+
+
+async def test_desafio_reports_github_errors(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.config import reload_settings
+    from acelerado.slash import cmd_desafio
+
+    reload_settings()
+
+    async def fake_find(repo, month, token=None):
+        raise challenge_github.GitHubError("404 from /repos/...")
+
+    monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    await cmd_desafio.callback(interaction)
+    msg = interaction.followup.send.await_args.args[0]
+    assert "GitHub" in msg
+    assert "404" in msg
+
+
 async def test_update_command_ok_schedules_restart(monkeypatch):
     import asyncio
 

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -412,19 +412,33 @@ async def test_config_unset_reverts_to_fallback(chdir_tmp):
 # ---------------------------------------------------------------------------
 
 
-def test_register_desafio_command():
+def test_register_desafio_group():
     tree = _build_tree()
     guild = discord.Object(id=1)
     register_commands(tree, guild=guild)
     cmd = tree.get_command("desafio", guild=guild)
     assert cmd is not None
-    assert cmd.name == "desafio"
+    assert isinstance(cmd, app_commands.Group)
+    sub_names = {c.name for c in cmd.commands}
+    assert sub_names == {"status", "resultados", "resultados-skip", "historico"}
+
+
+def _get_desafio_subcommand(name: str):
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    group = tree.get_command("desafio", guild=guild)
+    assert isinstance(group, app_commands.Group)
+    for cmd in group.commands:
+        if cmd.name == name:
+            return cmd
+    raise AssertionError(f"subcommand {name!r} not registered")
 
 
 async def test_desafio_responds_when_disabled(monkeypatch):
     monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -432,7 +446,7 @@ async def test_desafio_responds_when_disabled(monkeypatch):
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     interaction.response.send_message.assert_awaited_once()
     msg = interaction.response.send_message.await_args.args[0]
     assert "não estão habilitados" in msg.lower() or "habilitados" in msg.lower()
@@ -443,7 +457,7 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     from acelerado.challenges import github as challenge_github
     from acelerado.challenges.spec import load_spec
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -473,7 +487,7 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     interaction.response.defer.assert_awaited_once()
     interaction.followup.send.assert_awaited_once()
     embed = interaction.followup.send.await_args.kwargs.get("embed")
@@ -493,7 +507,7 @@ async def test_desafio_renders_when_submission_count_fails(monkeypatch):
     from acelerado.challenges import github as challenge_github
     from acelerado.challenges.spec import load_spec
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -523,7 +537,7 @@ async def test_desafio_renders_when_submission_count_fails(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     embed = interaction.followup.send.await_args.kwargs.get("embed")
     assert embed is not None
     submissions_field = next((f for f in embed.fields if f.name == "Submissões"), None)
@@ -535,7 +549,7 @@ async def test_desafio_handles_missing_challenge(monkeypatch):
     monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
     from acelerado.challenges import github as challenge_github
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -550,7 +564,7 @@ async def test_desafio_handles_missing_challenge(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     msg = interaction.followup.send.await_args.args[0]
     assert "Nenhum desafio" in msg
 
@@ -559,7 +573,7 @@ async def test_desafio_reports_github_errors(monkeypatch):
     monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
     from acelerado.challenges import github as challenge_github
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -574,10 +588,216 @@ async def test_desafio_reports_github_errors(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     msg = interaction.followup.send.await_args.args[0]
     assert "GitHub" in msg
     assert "404" in msg
+
+
+# ---------------------------------------------------------------------------
+# /desafio resultados / resultados-skip / historico (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+def _admin_interaction_with_bot(bot):
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+async def test_desafio_resultados_warns_when_review_channel_unset(monkeypatch):
+    monkeypatch.delenv("DISCORD_REVIEW_CHANNEL_ID", raising=False)
+    monkeypatch.setenv("DISCORD_CHALLENGES_CHANNEL_ID", "999")
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "REVIEW_CHANNEL_ID" in msg
+
+
+async def test_desafio_resultados_warns_when_target_channel_unset(monkeypatch):
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "555")
+    monkeypatch.delenv("DISCORD_CHALLENGES_CHANNEL_ID", raising=False)
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "CHALLENGES_CHANNEL_ID" in msg
+
+
+async def test_desafio_resultados_404_returns_friendly_message(monkeypatch):
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "555")
+    monkeypatch.setenv("DISCORD_CHALLENGES_CHANNEL_ID", "999")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    async def fake_fetch(repo, slug, token=None):
+        return None
+
+    monkeypatch.setattr(challenge_github, "fetch_results", fake_fetch)
+
+    fake_review = MagicMock(spec=discord.TextChannel)
+    fake_review.send = AsyncMock()
+    bot = MagicMock()
+    bot.get_channel.side_effect = lambda cid: fake_review if cid == 555 else None
+
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(bot)
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    msg = interaction.followup.send.await_args.args[0]
+    assert "não existe" in msg
+    fake_review.send.assert_not_awaited()
+
+
+async def test_desafio_resultados_posts_draft_with_view(monkeypatch, chdir_tmp):
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "555")
+    monkeypatch.setenv("DISCORD_CHALLENGES_CHANNEL_ID", "999")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges.results import load_results
+    from acelerado.challenges.state import ChallengesState
+    from acelerado.config import reload_settings
+    from acelerado.review import EditableDraftView
+
+    reload_settings()
+
+    results = load_results(
+        {
+            "slug": "2026-05-deblur",
+            "primary_metric": "psnr_mean_db",
+            "direction": "max",
+            "ranking": [{"rank": 1, "user": "alice", "metrics": {"psnr_mean_db": 41.2}}],
+        }
+    )
+
+    async def fake_fetch(repo, slug, token=None):
+        return results
+
+    monkeypatch.setattr(challenge_github, "fetch_results", fake_fetch)
+
+    fake_review = MagicMock(spec=discord.TextChannel)
+    fake_review.send = AsyncMock()
+    bot = MagicMock()
+    bot.get_channel.side_effect = lambda cid: fake_review if cid == 555 else None
+
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(bot)
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    fake_review.send.assert_awaited_once()
+    kwargs = fake_review.send.await_args.kwargs
+    assert "@alice" in kwargs.get("content", "")
+    assert isinstance(kwargs.get("view"), EditableDraftView)
+    assert kwargs["view"].target_channel_id == 999
+
+    # State now flags the slug as posted, killing the reminder.
+    assert ChallengesState().is_results_posted("2026-05-deblur")
+
+
+async def test_desafio_resultados_skip_marks_dismissed(monkeypatch, chdir_tmp):
+    from acelerado.challenges.state import ChallengesState
+
+    cmd = _get_desafio_subcommand("resultados-skip")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    assert ChallengesState().is_results_dismissed("2026-05-deblur")
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "silenciados" in msg
+
+
+async def test_desafio_historico_renders_embed(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from datetime import UTC, datetime
+
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges.results import load_results
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    challenge_github.clear_history_cache()
+
+    history = [
+        load_results(
+            {
+                "slug": "2026-05-deblur",
+                "primary_metric": "psnr_mean_db",
+                "direction": "max",
+                "ranking": [
+                    {"rank": 1, "user": "alice", "metrics": {"psnr_mean_db": 41.2}},
+                    {"rank": 2, "user": "bob", "metrics": {"psnr_mean_db": 39.8}},
+                ],
+            }
+        ),
+    ]
+    fixed_now = datetime(2026, 6, 5, 14, 23, tzinfo=UTC)
+
+    async def fake_get(repo, ttl=None, token=None):
+        return history, fixed_now
+
+    monkeypatch.setattr(challenge_github, "get_cached_history", fake_get)
+
+    cmd = _get_desafio_subcommand("historico")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    field = embed.fields[0]
+    assert "2026-05-deblur" in field.name
+    assert "@alice" in (field.value or "")
+    # Footer carries the freshness timestamp.
+    assert "2026-06-05" in (embed.footer.text or "")
+
+
+async def test_desafio_historico_blocked_when_disabled(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_desafio_subcommand("historico")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+
+
+async def test_desafio_historico_handles_empty(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from datetime import UTC, datetime
+
+    from acelerado.challenges import github as challenge_github
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    challenge_github.clear_history_cache()
+
+    async def fake_get(repo, ttl=None, token=None):
+        return [], datetime.now(UTC)
+
+    monkeypatch.setattr(challenge_github, "get_cached_history", fake_get)
+
+    cmd = _get_desafio_subcommand("historico")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction)
+
+    msg = interaction.followup.send.await_args.args[0]
+    assert "Ainda não há resultados" in msg
 
 
 async def test_update_command_ok_schedules_restart(monkeypatch):

--- a/tests/test_state_challenges.py
+++ b/tests/test_state_challenges.py
@@ -1,0 +1,197 @@
+"""Tests for the monthly-challenge announcement step in ``AceleradoState``.
+
+The GitHub helpers are patched so the step never makes real HTTP
+calls; we only exercise the gating logic (feature flag, day-of-month,
+hour-of-day, idempotency) and the channel routing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from acelerado import state as state_mod
+from acelerado import youtube as yt_mod
+from acelerado.challenges import github as challenge_github
+from acelerado.challenges.spec import load_spec
+
+SPEC_PAYLOAD = {
+    "name": "deblur",
+    "title": "arrumando autofoco",
+    "month": "2026-05",
+    "primary_metric": "psnr_mean_db",
+    "direction": "max",
+    "caps": {"time_ms_per_image": 200, "peak_rss_mb": 64},
+}
+
+
+@pytest.fixture
+def challenges_channel():
+    """Mock channel with a spec'd send method, like the announce/log channels."""
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.name = "desafios"
+    channel.send = AsyncMock()
+    return channel
+
+
+@pytest.fixture
+def state_with_challenges(chdir_tmp, fake_bot, fake_guild, monkeypatch, challenges_channel):
+    """AceleradoState with the challenges channel wired in (id 444)."""
+    monkeypatch.setattr(yt_mod, "get_last_videos", lambda max_videos=20: [])
+
+    # Extend the bot's channel map to include the challenges channel.
+    original_side_effect = fake_bot.get_channel.side_effect
+
+    def get_channel(cid: int):
+        if cid == 444:
+            return challenges_channel
+        return original_side_effect(cid)
+
+    fake_bot.get_channel.side_effect = get_channel
+
+    monkeypatch.setenv("DISCORD_CHALLENGES_CHANNEL_ID", "444")
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ANNOUNCE_DAY", "1")
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ANNOUNCE_HOUR_UTC", "0")
+    # The autouse ``clear_caches`` fixture already calls reload_settings,
+    # but env was set after that ran — force a re-read.
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    return state_mod.AceleradoState(fake_bot)
+
+
+def _patch_now(monkeypatch, when: datetime) -> None:
+    class _FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            if tz is None:
+                return when.replace(tzinfo=None)
+            return when.astimezone(tz)
+
+    monkeypatch.setattr(state_mod, "datetime", _FakeDateTime)
+
+
+async def _patch_find(monkeypatch, spec):
+    async def fake_find(repo, month, token=None):
+        return spec
+
+    monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+
+
+async def test_announce_skipped_when_disabled(
+    state_with_challenges, monkeypatch, challenges_channel
+):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    _patch_now(monkeypatch, datetime(2026, 5, 1, 12, tzinfo=UTC))
+    await state_with_challenges._announce_new_challenge()
+
+    challenges_channel.send.assert_not_awaited()
+
+
+async def test_announce_skipped_when_not_announce_day(
+    state_with_challenges, monkeypatch, challenges_channel
+):
+    _patch_now(monkeypatch, datetime(2026, 5, 15, 12, tzinfo=UTC))
+    await state_with_challenges._announce_new_challenge()
+    challenges_channel.send.assert_not_awaited()
+
+
+async def test_announce_skipped_when_before_hour(
+    state_with_challenges, monkeypatch, challenges_channel
+):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ANNOUNCE_HOUR_UTC", "12")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    _patch_now(monkeypatch, datetime(2026, 5, 1, 11, tzinfo=UTC))
+    await state_with_challenges._announce_new_challenge()
+    challenges_channel.send.assert_not_awaited()
+
+
+async def test_announce_posts_when_conditions_met(
+    state_with_challenges, monkeypatch, challenges_channel
+):
+    _patch_now(monkeypatch, datetime(2026, 5, 1, 12, tzinfo=UTC))
+    await _patch_find(monkeypatch, load_spec(SPEC_PAYLOAD))
+
+    await state_with_challenges._announce_new_challenge()
+
+    challenges_channel.send.assert_awaited_once()
+    msg = challenges_channel.send.await_args.args[0]
+    assert "arrumando autofoco" in msg
+    assert "PSNR" in msg
+    # Idempotency marker landed on disk.
+    assert state_with_challenges.challenges.is_announced("2026-05-deblur")
+
+
+async def test_announce_idempotent_within_same_month(
+    state_with_challenges, monkeypatch, challenges_channel
+):
+    _patch_now(monkeypatch, datetime(2026, 5, 1, 12, tzinfo=UTC))
+    await _patch_find(monkeypatch, load_spec(SPEC_PAYLOAD))
+
+    await state_with_challenges._announce_new_challenge()
+    await state_with_challenges._announce_new_challenge()
+
+    assert challenges_channel.send.await_count == 1
+
+
+async def test_announce_skipped_when_channel_unset(chdir_tmp, fake_bot, monkeypatch):
+    monkeypatch.setattr(yt_mod, "get_last_videos", lambda max_videos=20: [])
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    monkeypatch.delenv("DISCORD_CHALLENGES_CHANNEL_ID", raising=False)
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    state = state_mod.AceleradoState(fake_bot)
+    _patch_now(monkeypatch, datetime(2026, 5, 1, 12, tzinfo=UTC))
+    # Should NOT call find_current_spec (the channel guard precedes it).
+    called = False
+
+    async def fake_find(repo, month, token=None):
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+
+    await state._announce_new_challenge()
+    assert called is False
+
+
+async def test_announce_skipped_when_no_challenge_published(
+    state_with_challenges, monkeypatch, challenges_channel
+):
+    _patch_now(monkeypatch, datetime(2026, 6, 1, 12, tzinfo=UTC))
+    await _patch_find(monkeypatch, None)
+
+    await state_with_challenges._announce_new_challenge()
+    challenges_channel.send.assert_not_awaited()
+
+
+async def test_announce_persists_across_state_instances(
+    state_with_challenges, monkeypatch, challenges_channel, fake_bot, chdir_tmp: Path
+):
+    _patch_now(monkeypatch, datetime(2026, 5, 1, 12, tzinfo=UTC))
+    await _patch_find(monkeypatch, load_spec(SPEC_PAYLOAD))
+
+    await state_with_challenges._announce_new_challenge()
+    assert challenges_channel.send.await_count == 1
+
+    # New state instance reading the same disk file shouldn't re-announce.
+    monkeypatch.setattr(yt_mod, "get_last_videos", lambda max_videos=20: [])
+    fresh = state_mod.AceleradoState(fake_bot)
+    await fresh._announce_new_challenge()
+    assert challenges_channel.send.await_count == 1

--- a/tests/test_state_challenges.py
+++ b/tests/test_state_challenges.py
@@ -195,3 +195,84 @@ async def test_announce_persists_across_state_instances(
     fresh = state_mod.AceleradoState(fake_bot)
     await fresh._announce_new_challenge()
     assert challenges_channel.send.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — _remind_pending_results
+# ---------------------------------------------------------------------------
+
+
+async def _patch_slugs(monkeypatch, slugs):
+    async def fake_list(repo, token=None):
+        return list(slugs)
+
+    monkeypatch.setattr(challenge_github, "list_challenge_slugs", fake_list)
+
+
+async def test_reminder_skipped_when_disabled(state_with_challenges, monkeypatch, fake_guild):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()
+
+
+async def test_reminder_posts_for_past_month_slug(state_with_challenges, monkeypatch, fake_guild):
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur", "2026-06-active"])
+
+    await state_with_challenges._remind_pending_results()
+
+    fake_guild._log.send.assert_awaited_once()
+    msg = fake_guild._log.send.await_args.args[0]
+    # Active month (2026-06) should NOT be nudged.
+    assert "2026-05-deblur" in msg
+    assert "2026-06-active" not in msg
+
+
+async def test_reminder_skips_slugs_already_posted(state_with_challenges, monkeypatch, fake_guild):
+    state_with_challenges.challenges.mark_results_posted("2026-05-deblur")
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()
+
+
+async def test_reminder_skips_slugs_dismissed(state_with_challenges, monkeypatch, fake_guild):
+    state_with_challenges.challenges.mark_results_dismissed("2026-05-deblur")
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()
+
+
+async def test_reminder_rate_limited_to_24h(state_with_challenges, monkeypatch, fake_guild):
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    await state_with_challenges._remind_pending_results()
+
+    # Two ticks within the cooldown window — only one reminder.
+    assert fake_guild._log.send.await_count == 1
+
+
+async def test_reminder_swallows_github_errors(state_with_challenges, monkeypatch, fake_guild):
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+
+    async def boom(repo, token=None):
+        raise challenge_github.GitHubError("rate limited")
+
+    monkeypatch.setattr(challenge_github, "list_challenge_slugs", boom)
+
+    # Must NOT raise — the tick wraps each step in try/except, but we
+    # still want this step to handle expected errors locally.
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "textual" },
@@ -28,6 +29,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -37,6 +39,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.150" },
     { name = "google-auth-httplib2", specifier = ">=0.2" },
     { name = "google-auth-oauthlib", specifier = ">=1.2" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.5" },
     { name = "textual", specifier = ">=0.80" },
@@ -49,6 +52,7 @@ dev = [
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=5" },
+    { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.6" },
 ]
 
@@ -192,6 +196,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -813,6 +830,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httplib2"
 version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
@@ -822,6 +861,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1569,6 +1623,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Liga o bot ao novo repo [`wainejr/acelerado-desafios`](https://github.com/wainejr/acelerado-desafios). Cobre as 3 fases da issue #37 num só PR.

## Resumo por fase

### Fase 1 — anúncio mensal + `/desafio status`

- Pacote novo `acelerado/challenges/`:
  - `spec.py` — pydantic `Spec` (`extra="allow"`) preserva campos extras do `spec.json` (`image`, `psf`, `bench`, …).
  - `github.py` — cliente async em httpx; lista pastas `YYYY-MM-*` em `/contents`, busca `spec.json` via `raw.githubusercontent.com`. `GITHUB_TOKEN` opcional, nunca escreve em `config.json`.
  - `state.py` — `challenges_state.json` atômico, idempotência keyed pelo slug.
  - `announce.py` — copy consciente da métrica/direção, fallback genérico para métricas desconhecidas.
- Step `_announce_new_challenge` em `state.py` gateado por feature flag + dia + hora UTC + canal configurado.
- Configs novas em `env.py` (todas opt-in): `ACELERADO_CHALLENGES_ENABLED`, `ACELERADO_CHALLENGES_REPO`, `DISCORD_CHALLENGES_CHANNEL_ID`, `ACELERADO_CHALLENGES_ANNOUNCE_DAY` / `_HOUR_UTC`.
- Métrica nova `challenges_announced` em `metrics.py`.

### Fase 2 — contagem de submissões no embed

Escopo enxuto: contagem via comando, **sem** pulse diário, **sem** listar usuários, **sem** matching Discord↔GitHub.

- `count_open_submissions(repo)` em `github.py` — uma chamada em `GET /repos/{repo}/pulls?state=open&per_page=100`. Convenção do repo: todo PR aberto é uma submissão.
- O embed do `/desafio status` ganha campo *Submissões*: `📊 N submissões abertas — [ver PRs](github.com/.../pulls)`. Falha vira *"indisponível"*, não derruba o embed.

### Fase 3 — pipeline manual de resultados + reminders + histórico

Sem step automático que posta o draft sozinho. Você dispara via slash quando rodar os benchmarks; o bot lembra mensalmente até ação.

- **Comando manual:** `/desafio resultados <slug>` (admin) busca `<slug>/results.json` no repo, renderiza um draft Markdown consciente da métrica primária, e posta no `DISCORD_REVIEW_CHANNEL_ID` com a `View` editorial (Aprovar → posta no `DISCORD_CHALLENGES_CHANNEL_ID`; Editar → modal; Descartar → arquiva).
- **Skip manual:** `/desafio resultados-skip <slug>` (admin) marca o slug como dismissed e silencia o reminder.
- **Reminder no canal de log:** step novo `_remind_pending_results` percorre slugs cujo `YYYY-MM` é estritamente passado E não está em `results_posted` nem em `results_dismissed`, posta lembrete 1×/24h por slug:
  > 📋 Resultados de **2026-05-deblur** pendentes. Use `/desafio resultados 2026-05-deblur` quando rodar os benchmarks, ou `/desafio resultados-skip 2026-05-deblur` pra parar de avisar.
- **Histórico cacheado:** `/desafio historico` (público) mostra top-3 dos desafios passados com cache de 6h em memória; footer do embed mostra *"Última atualização: …"*.
- **Renderer consciente da métrica:** `acelerado/challenges/results.py` com pydantic `Results` (`extra="allow"`, espelha o `Spec` — métricas variam). `format_metric_value` cobre `time_ms` / `time_ms_per_image` (com break em 1s), `peak_rss_mb`, `disk_write_mb`, `binary_size_bytes` / `code_size_bytes` humanizados, `psnr_mean_db`. Métricas desconhecidas: `str(value)`.
- **Refator:** `WeeklySummaryView` → `EditableDraftView` genérico (`(draft_text, target_channel_id, modal_title)`). Reusado pela Fase 3 e pelo summary semanal; comportamento idêntico, 0 testes do `review.py` mudaram.

### `/desafio` agora é um slash group

| Subcomando | Acesso | Função |
|---|---|---|
| `status` | público | Desafio do mês + contagem de PRs (Fases 1+2). |
| `resultados <slug>` | admin | Posta draft no canal de review (Fase 3). |
| `resultados-skip <slug>` | admin | Silencia reminders (Fase 3). |
| `historico` | público | Top-3 dos desafios passados, cache 6h (Fase 3). |

### State adições (`challenges_state.json`)

- `announced: list[slug]` (Fase 1) — slugs já anunciados.
- `results_posted: list[slug]` (Fase 3) — slugs cujo draft foi enviado.
- `results_dismissed: list[slug]` (Fase 3) — slugs onde mandou parar de cobrar.
- `last_remind_at: dict[slug, ISO]` (Fase 3) — rate-limit do reminder.

## Discovery — por que dessa forma

GH Pages do site (`wainejr.github.io/acelerado-desafios/`) é HTML-only — sem `index.json` / sitemap utilizável. Então:
- Listagem das pastas: `GET /repos/{repo}/contents` (autenticado se `GITHUB_TOKEN` setado, anônimo caso contrário). Filtro por regex `^\d{4}-(0[1-9]|1[0-2])-…`.
- Conteúdo do `spec.json` / `results.json`: `raw.githubusercontent.com/.../HEAD/<slug>/<arquivo>` (mais barato que `/contents` que retornaria base64).
- Link público no anúncio: `https://wainejr.github.io/acelerado-desafios/desafios/<slug>/`.

Rate-limit ainda dá folga (60/h anônimo, 5000/h com token). Cache de 6h no histórico evita N+1 chamadas a cada `/desafio historico`.

## Schemas frouxos — métricas variam

Tanto `Spec` quanto `Results` usam `extra="allow"`. Isso significa:
- `spec.json` real do `2026-05-deblur` tem `primary_metric: "psnr_mean_db"` (a issue listava só `quality`) + blocos `image`/`psf`/`noise`/`validation`/`io`/`bench` — todos preservados sem precisar modelar.
- Quando uma fase futura precisar do `bench.measured_runs`, é só ler `spec.model_extra["bench"]`.
- Métricas novas em `results.json` não quebram o renderer — ele faz fallback pra `str(value)` quando não conhece a chave.

## Test plan

- [x] `uv run pytest` — **343 passam** (Fase 1: 32 novos; Fase 2: 5 novos; Fase 3: 50 novos).
- [x] `uv run ruff check` + `ruff format --check` — limpos.
- [x] `uv run mypy acelerado` — limpo.
- [ ] Smoke manual Fase 1: setar `ACELERADO_CHALLENGES_ENABLED=true` + canal, forçar `ACELERADO_CHALLENGES_ANNOUNCE_DAY` pro dia atual, ver post.
- [ ] Smoke manual Fase 2: rodar `/desafio status`, conferir contagem de PRs.
- [ ] Smoke manual Fase 3: commitar `2026-05-deblur/results.json` no repo, rodar `/desafio resultados 2026-05-deblur`, aprovar via View, conferir post no canal de desafios. Rodar `/desafio historico`. Forçar slug-no-passado sem flags pra ver reminder no log.

Refs #37 (Fases 1+2+3 completas). Fase 3 não bloqueia em #36 — a infra de View já estava no `review.py` shipado anteriormente; só foi generalizada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
