### PR TITLE
feat(challenges): expose open-PR count in /desafio (Phase 2)

### DIFF
--- a/acelerado/challenges/github.py
+++ b/acelerado/challenges/github.py
@@ -154,3 +154,28 @@ async def find_current_spec(
         if slug_month(slug) == month:
             return await fetch_spec(repo, slug, token=token)
     return None
+
+
+async def count_open_submissions(repo: str, token: str | None = None) -> int:
+    """Return the number of open pull requests targeting ``repo``.
+
+    For the challenges repo every open PR is, by convention, a
+    submission — there's no other ongoing work in that repo. So PR
+    count is the cheapest signal of community activity. We don't list
+    authors anywhere; the URL we surface in ``/desafio`` lets the user
+    inspect them directly on GitHub if they want.
+
+    Pagination: GitHub's PR endpoint defaults to 30 per page and caps at
+    100. A monthly challenge with >100 open PRs would be a very nice
+    problem to have; if we ever hit it, we'll add `?page=`. For now we
+    cap at one page (``per_page=100``) and trust the cap.
+    """
+    token = _resolve_token(token)
+    async with _client(token) as client:
+        prs = await _get_json(
+            client,
+            f"/repos/{repo}/pulls?state=open&per_page=100",
+        )
+    if not isinstance(prs, list):
+        raise GitHubError(f"expected list from /pulls, got {type(prs).__name__}")
+    return len(prs)

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -227,6 +227,18 @@ async def cmd_desafio(interaction: discord.Interaction) -> None:
         )
         return
 
+    # Submission count is best-effort — a flaky GitHub call shouldn't
+    # tank the whole reply. We surface "indisponível" inline instead.
+    try:
+        open_prs = await challenge_github.count_open_submissions(
+            cfg.ACELERADO_CHALLENGES_REPO,
+        )
+        submissions_line = f"📊 **{open_prs}** submissões abertas"
+    except challenge_github.GitHubError:
+        submissions_line = "📊 Submissões: indisponível no momento"
+
+    pr_url = f"https://github.com/{cfg.ACELERADO_CHALLENGES_REPO}/pulls"
+
     embed = discord.Embed(
         title=f"🏁 Desafio de {spec.month} — {spec.title}",
         description=challenge_announce.render_short_status(spec),
@@ -242,6 +254,11 @@ async def cmd_desafio(interaction: discord.Interaction) -> None:
             inline=False,
         )
     embed.add_field(name="Enunciado", value=spec.site_url, inline=False)
+    embed.add_field(
+        name="Submissões",
+        value=f"{submissions_line} — [ver PRs]({pr_url})",
+        inline=False,
+    )
     await interaction.followup.send(embed=embed, ephemeral=True)
 
 

--- a/tests/test_challenges_github.py
+++ b/tests/test_challenges_github.py
@@ -123,6 +123,47 @@ async def test_no_token_means_no_authorization_header(monkeypatch):
     assert "Authorization" not in route.calls.last.request.headers
 
 
+@respx.mock
+async def test_count_open_submissions_returns_length_of_pr_list():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"number": 1, "user": {"login": "alice"}},
+                {"number": 2, "user": {"login": "bob"}},
+                {"number": 3, "user": {"login": "carol"}},
+            ],
+        )
+    )
+    assert await gh.count_open_submissions(REPO) == 3
+
+
+@respx.mock
+async def test_count_open_submissions_zero_when_empty():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    assert await gh.count_open_submissions(REPO) == 0
+
+
+@respx.mock
+async def test_count_open_submissions_raises_on_http_error():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    with pytest.raises(gh.GitHubError, match="500"):
+        await gh.count_open_submissions(REPO)
+
+
+@respx.mock
+async def test_count_open_submissions_raises_on_non_list_payload():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/pulls?state=open&per_page=100").mock(
+        return_value=httpx.Response(200, json={"unexpected": "shape"})
+    )
+    with pytest.raises(gh.GitHubError, match="expected list"):
+        await gh.count_open_submissions(REPO)
+
+
 def test_slug_month_extracts_prefix():
     assert gh.slug_month("2026-05-deblur") == "2026-05"
     assert gh.slug_month("2026-12-foo-bar") == "2026-12"

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -461,7 +461,11 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     async def fake_find(repo, month, token=None):
         return spec
 
+    async def fake_count(repo, token=None):
+        return 7
+
     monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+    monkeypatch.setattr(challenge_github, "count_open_submissions", fake_count)
 
     interaction = MagicMock(spec=discord.Interaction)
     interaction.response = MagicMock()
@@ -476,6 +480,55 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     assert isinstance(embed, discord.Embed)
     assert "arrumando autofoco" in (embed.title or "")
     assert embed.url == spec.site_url
+    # Submissions count + PR link landed in a dedicated field.
+    submissions_field = next((f for f in embed.fields if f.name == "Submissões"), None)
+    assert submissions_field is not None
+    assert "7" in (submissions_field.value or "")
+    assert "/pulls" in (submissions_field.value or "")
+
+
+async def test_desafio_renders_when_submission_count_fails(monkeypatch):
+    """A flaky GitHub call on ``count_open_submissions`` must not break the embed."""
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges.spec import load_spec
+    from acelerado.config import reload_settings
+    from acelerado.slash import cmd_desafio
+
+    reload_settings()
+
+    spec = load_spec(
+        {
+            "name": "deblur",
+            "title": "arrumando autofoco",
+            "month": "2026-05",
+            "primary_metric": "psnr_mean_db",
+            "direction": "max",
+            "caps": {},
+        }
+    )
+
+    async def fake_find(repo, month, token=None):
+        return spec
+
+    async def fake_count_boom(repo, token=None):
+        raise challenge_github.GitHubError("rate limited")
+
+    monkeypatch.setattr(challenge_github, "find_current_spec", fake_find)
+    monkeypatch.setattr(challenge_github, "count_open_submissions", fake_count_boom)
+
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+
+    await cmd_desafio.callback(interaction)
+    embed = interaction.followup.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    submissions_field = next((f for f in embed.fields if f.name == "Submissões"), None)
+    assert submissions_field is not None
+    assert "indisponível" in (submissions_field.value or "")
 
 
 async def test_desafio_handles_missing_challenge(monkeypatch):


### PR DESCRIPTION
Stack em cima de #38. Implementa a Fase 2 da issue #37 no escopo enxuto que combinamos: contagem de submissões via comando, sem pulse diário, sem listar usuários, sem matching Discord↔GitHub.

## Summary

- `count_open_submissions(repo)` em `challenges/github.py` — uma chamada em `GET /repos/{repo}/pulls?state=open&per_page=100`. Convenção do repo: todo PR aberto é uma submissão.
- `/desafio` ganha um campo *Submissões* no embed: \`📊 N submissões abertas — [ver PRs](github.com/.../pulls)\`. O usuário acha o próprio PR num clique.
- Fallback elegante: se a chamada falhar (rate limit, rede), o campo vira *"indisponível no momento"* e o resto do embed segue intacto.

## Decisões fechadas (do alinhamento)

- **Submissão = PR aberto** (sinal mais limpo; branch nua sem PR pode ser WIP eterno).
- **Sem pulse diário** — só comando.
- **Sem listar usuários** em nenhum output.
- **Sem status per-user** no \`/desafio\` (cancelado).

## Test plan

- [x] \`uv run pytest\` — 293 passam (5 novos: 4 cobrindo \`count_open_submissions\` (sucesso, vazio, HTTP error, payload inválido) + 1 cobrindo o fallback do embed quando a chamada falha; \`/desafio\` existente atualizado pra cobrir o novo campo).
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` + \`uv run mypy acelerado\` — todos limpos.
- [ ] Smoke manual: rodar \`/desafio\` num server com a feature ligada, conferir contagem + link.

Refs #37 (Fase 2). Fica como dependência: #38 (Fase 1) precisa entrar antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)