### PR TITLE
feat(challenges): manual results draft + history command (Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,10 @@ acelerado/
   log.py          # setup_logging() with RichHandler
   challenges/     # monthly performance-challenge integration (issue #37)
     spec.py       #   pydantic Spec for spec.json (extra="allow")
-    github.py     #   async httpx client for the desafios repo
-    state.py      #   challenges_state.json — announce idempotency
-    announce.py   #   metric-aware copy renderer
+    github.py     #   async httpx client for the desafios repo + history cache
+    state.py      #   challenges_state.json — announce + results posted/dismissed/last_remind
+    announce.py   #   metric-aware announcement copy renderer
+    results.py    #   pydantic Results + metric-aware results post renderer (Phase 3)
 scripts/
   send_token.sh   # SCP token.pickle to a remote host
 .github/workflows/
@@ -74,7 +75,11 @@ token.pickle      # cached OAuth user token
    - Skip if not yet processed (unless it's a livestream).
    - Skip vertical videos (Shorts).
    - Message wording differs for livestream / members-only / regular video.
-4. **Monthly challenges** (issue #37, Phase 1) — gated by `ACELERADO_CHALLENGES_ENABLED`; on the configured day/hour, query the `wainejr/acelerado-desafios` repo via the GitHub REST API, locate the `YYYY-MM-*` folder for the current month, fetch its `spec.json`, and post a metric-aware announcement in `DISCORD_CHALLENGES_CHANNEL_ID`. Idempotency lives in `challenges_state.json` (slug-keyed, not month-keyed). `/desafio` slash command exposes the same lookup ephemerally.
+4. **Monthly challenges** (issue #37) — gated by `ACELERADO_CHALLENGES_ENABLED`. Two tick steps:
+   - `_announce_new_challenge` (Phase 1): on the configured day/hour, query the `wainejr/acelerado-desafios` repo via the GitHub REST API, locate the `YYYY-MM-*` folder for the current month, fetch its `spec.json`, and post a metric-aware announcement in `DISCORD_CHALLENGES_CHANNEL_ID`. Idempotency lives in `challenges_state.json` (slug-keyed, not month-keyed).
+   - `_remind_pending_results` (Phase 3): for every challenge folder whose `YYYY-MM` is in the past and which is neither posted nor dismissed in state, post a 1×/24h reminder in the **log channel** so the operator gets nudged to run `/desafio resultados <slug>` (or `/desafio resultados-skip <slug>` to mute).
+
+   `/desafio` is a slash group: `status` (current challenge + open-PR count, public), `resultados <slug>` (admin — fetches `results.json`, renders metric-aware draft, posts to `DISCORD_REVIEW_CHANNEL_ID` with the editorial `EditableDraftView`), `resultados-skip <slug>` (admin — silences reminders), `historico` (top-3 of past challenges, 6h cache, footer shows last fetch).
 
 ## Required env (`.env`)
 

--- a/acelerado/challenges/github.py
+++ b/acelerado/challenges/github.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 import logging
 import os
 import re
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
 
+from acelerado.challenges.results import Results, load_results
 from acelerado.challenges.spec import Spec, load_spec
 
 logger = logging.getLogger(__name__)
@@ -154,6 +156,92 @@ async def find_current_spec(
         if slug_month(slug) == month:
             return await fetch_spec(repo, slug, token=token)
     return None
+
+
+async def fetch_results(
+    repo: str,
+    slug: str,
+    token: str | None = None,
+) -> Results | None:
+    """Fetch and validate ``<slug>/results.json``.
+
+    Returns ``None`` when the file doesn't exist (404 from raw) — that's
+    a normal state during the active month before benchmarks have run.
+    Other HTTP / JSON errors raise :class:`GitHubError`.
+    """
+    token = _resolve_token(token)
+    url = f"https://raw.githubusercontent.com/{repo}/HEAD/{slug}/results.json"
+    async with httpx.AsyncClient(
+        headers=_headers(token),
+        timeout=DEFAULT_TIMEOUT,
+    ) as client:
+        try:
+            response = await client.get(url)
+        except httpx.HTTPError as exc:
+            raise GitHubError(f"network error fetching {url}: {exc}") from exc
+        if response.status_code == 404:
+            return None
+        if response.status_code >= 400:
+            raise GitHubError(f"{response.status_code} from {url}: {response.text[:200]}")
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise GitHubError(f"invalid JSON from {url}: {exc}") from exc
+    return load_results(data)
+
+
+async def list_past_results(repo: str, token: str | None = None) -> list[Results]:
+    """Return every ``results.json`` found under the repo's challenge folders.
+
+    Slugs that don't have a ``results.json`` yet are skipped silently —
+    typical for the active month. Order: most-recent slug first
+    (lexicographic on ``YYYY-MM`` sorts chronologically).
+    """
+    slugs = await list_challenge_slugs(repo, token=token)
+    out: list[Results] = []
+    for slug in sorted(slugs, reverse=True):
+        results = await fetch_results(repo, slug, token=token)
+        if results is not None:
+            out.append(results)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cached historic results
+#
+# The history listing walks every challenge folder and fetches each
+# results.json — that's N+1 requests against GitHub. Caching the
+# aggregate per-repo for a few hours keeps ``/desafio historico`` snappy
+# and stays well under rate limits even with steady use.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_HISTORY_TTL = timedelta(hours=6)
+_history_cache: dict[str, tuple[datetime, list[Results]]] = {}
+
+
+def clear_history_cache() -> None:
+    """Drop the in-memory cache (test helper / forced refresh)."""
+    _history_cache.clear()
+
+
+async def get_cached_history(
+    repo: str,
+    *,
+    ttl: timedelta = _DEFAULT_HISTORY_TTL,
+    token: str | None = None,
+) -> tuple[list[Results], datetime]:
+    """Return ``(results, fetched_at)`` honoring a per-repo TTL.
+
+    The timestamp travels with the data so callers can show *"última
+    atualização: …"* without re-checking the cache themselves.
+    """
+    now = datetime.now(UTC)
+    cached = _history_cache.get(repo)
+    if cached is not None and (now - cached[0]) < ttl:
+        return cached[1], cached[0]
+    fresh = await list_past_results(repo, token=token)
+    _history_cache[repo] = (now, fresh)
+    return fresh, now
 
 
 async def count_open_submissions(repo: str, token: str | None = None) -> int:

--- a/acelerado/challenges/results.py
+++ b/acelerado/challenges/results.py
@@ -1,0 +1,196 @@
+"""Schema + renderer for ``results.json``.
+
+Each challenge ends with the maintainer committing a ``results.json``
+to ``<slug>/`` in the desafios repo. Shape is deliberately loose —
+metrics vary per challenge (PSNR for deblur, time for mandelbrot,
+peak RSS for ext-sort, …) — so :class:`Entry.metrics` is an opaque
+dict the renderer formats by name. Unknown metric keys fall through
+to ``str(value)``.
+
+The renderer produces a Markdown draft in PT-BR; it never posts on its
+own. The draft flows through :class:`acelerado.review.EditableDraftView`
+for human approval before going public.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Metric direction is duplicated in spec.json; results.json carries it
+# again for self-containment so the renderer doesn't need both files in
+# memory just to know which way the ranking points.
+
+
+class Entry(BaseModel):
+    """One ranked submission. ``metrics`` mirrors per-run fields."""
+
+    model_config = ConfigDict(extra="allow")
+
+    rank: int
+    user: str
+    language: str | None = None
+    metrics: dict[str, Any] = Field(default_factory=dict)
+
+
+class Disqualified(BaseModel):
+    """One entry that failed validation or busted a cap."""
+
+    model_config = ConfigDict(extra="allow")
+
+    user: str
+    reason: str
+
+
+class Results(BaseModel):
+    """Full results payload for one challenge.
+
+    Extra fields at the top level are kept (``extra="allow"``) so the
+    bot doesn't need to know about every future enrichment (timing
+    breakdowns, hardware notes, …) just to render the post.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    slug: str
+    primary_metric: str
+    direction: str
+    ranking: list[Entry] = Field(default_factory=list)
+    disqualified: list[Disqualified] = Field(default_factory=list)
+
+
+def load_results(data: dict[str, Any]) -> Results:
+    return Results.model_validate(data)
+
+
+def load_results_file(path: Path) -> Results:
+    return load_results(json.loads(path.read_text(encoding="utf-8")))
+
+
+# ---------------------------------------------------------------------------
+# Metric value formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_time_ms(value: Any) -> str:
+    """Render a millisecond value as either ``ms`` or ``s`` depending on size."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if v >= 1000:
+        return f"{v / 1000:.2f} s"
+    return f"{v:.0f} ms"
+
+
+def _format_bytes(value: Any) -> str:
+    """Humanize a byte count with KB/MB suffixes."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if v >= 1_000_000:
+        return f"{v / 1_000_000:.2f} MB"
+    if v >= 1_000:
+        return f"{v / 1_000:.1f} KB"
+    return f"{v:.0f} B"
+
+
+def _format_float(value: Any, suffix: str) -> str:
+    try:
+        return f"{float(value):.2f} {suffix}".rstrip()
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def format_metric_value(metric: str, value: Any) -> str:
+    """Format ``value`` according to ``metric`` semantics.
+
+    Unknown metrics fall through to ``str(value)`` — better than
+    raising on a future metric we haven't taught the renderer about.
+    """
+    if metric in {"time_ms", "time_ms_per_image"}:
+        rendered = _format_time_ms(value)
+        if metric == "time_ms_per_image":
+            return f"{rendered}/img"
+        return rendered
+    if metric in {"peak_rss_mb", "disk_write_mb"}:
+        try:
+            return f"{float(value):.0f} MB"
+        except (TypeError, ValueError):
+            return str(value)
+    if metric in {"binary_size_bytes", "code_size_bytes"}:
+        return _format_bytes(value)
+    if metric == "psnr_mean_db":
+        return _format_float(value, "dB")
+    if metric == "quality":
+        return _format_float(value, "")
+    return str(value)
+
+
+_PODIUM_EMOJI = {1: "🥇", 2: "🥈", 3: "🥉"}
+
+
+def _entry_line(entry: Entry, primary: str) -> str:
+    """Headline for one ranking entry — rank emoji + user + primary metric."""
+    emoji = _PODIUM_EMOJI.get(entry.rank, "🔹")
+    primary_value = entry.metrics.get(primary, "—")
+    primary_str = format_metric_value(primary, primary_value)
+    return f"{emoji} **{entry.rank}º:** @{entry.user} — **{primary_str}**"
+
+
+def _entry_secondary_line(entry: Entry, primary: str) -> str | None:
+    """Compact stats line shown below the headline.
+
+    Includes secondary metrics (anything in ``entry.metrics`` other than
+    the primary) plus the language if known. Returns ``None`` if there's
+    nothing meaningful to show — caller skips the line entirely.
+    """
+    parts: list[str] = []
+    for key, value in entry.metrics.items():
+        if key == primary:
+            continue
+        parts.append(format_metric_value(key, value))
+    if entry.language:
+        parts.append(entry.language)
+    return " · ".join(parts) if parts else None
+
+
+def render_results_post(results: Results) -> str:
+    """Render the full Markdown post for posting in the challenges channel."""
+    lines = [f"## 🏁 Resultados — {results.slug}", ""]
+
+    if not results.ranking:
+        lines.append("_Sem submissões válidas neste desafio._")
+    else:
+        # Top 3 each get a headline + secondary line (when applicable);
+        # ranks 4+ collapse into a one-liner per entry to keep posts
+        # short on busy months.
+        primary = results.primary_metric
+        top = [e for e in results.ranking if e.rank <= 3]
+        rest = [e for e in results.ranking if e.rank > 3]
+
+        for entry in top:
+            lines.append(_entry_line(entry, primary))
+            secondary = _entry_secondary_line(entry, primary)
+            if secondary:
+                lines.append(f"   {secondary}")
+            lines.append("")
+
+        if rest:
+            lines.append("**Demais participantes:**")
+            for entry in rest:
+                lines.append(f"• {_entry_line(entry, primary)}")
+            lines.append("")
+
+    if results.disqualified:
+        lines.append("---")
+        lines.append(f"**Desclassificados ({len(results.disqualified)}):**")
+        for d in results.disqualified:
+            lines.append(f"• @{d.user} — {d.reason}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/acelerado/challenges/state.py
+++ b/acelerado/challenges/state.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -69,6 +70,73 @@ class ChallengesState:
         if slug in announced:
             return
         announced.append(slug)
+        self._flush()
+
+    # ------------------------------------------------------------------
+    # Results posting (Phase 3) — manual via /desafio resultados.
+    # The state tracks slugs already drafted (so we don't re-cobrar
+    # them) and slugs explicitly skipped (operator told us to stop).
+    # ``last_remind_at`` rate-limits the reminder step to 1×/24h per
+    # slug regardless of tick frequency.
+    # ------------------------------------------------------------------
+
+    def _list(self, key: str) -> list[str]:
+        value = self._data.get(key, [])
+        return value if isinstance(value, list) else []
+
+    def is_results_posted(self, slug: str) -> bool:
+        return slug in self._list("results_posted")
+
+    def mark_results_posted(self, slug: str) -> None:
+        posted = self._data.setdefault("results_posted", [])
+        if not isinstance(posted, list):
+            posted = []
+            self._data["results_posted"] = posted
+        if slug in posted:
+            return
+        posted.append(slug)
+        self._flush()
+
+    def is_results_dismissed(self, slug: str) -> bool:
+        return slug in self._list("results_dismissed")
+
+    def mark_results_dismissed(self, slug: str) -> None:
+        dismissed = self._data.setdefault("results_dismissed", [])
+        if not isinstance(dismissed, list):
+            dismissed = []
+            self._data["results_dismissed"] = dismissed
+        if slug in dismissed:
+            return
+        dismissed.append(slug)
+        self._flush()
+
+    def should_remind(self, slug: str, *, cooldown: timedelta = timedelta(hours=24)) -> bool:
+        """Return ``True`` iff we haven't reminded about ``slug`` recently.
+
+        Posted/dismissed slugs short-circuit to ``False`` regardless of
+        the cooldown — once acted on, the reminder is done forever.
+        """
+        if self.is_results_posted(slug) or self.is_results_dismissed(slug):
+            return False
+        last = (
+            self._data.get("last_remind_at", {}).get(slug)
+            if isinstance(self._data.get("last_remind_at"), dict)
+            else None
+        )
+        if last is None:
+            return True
+        try:
+            last_dt = datetime.fromisoformat(last)
+        except (TypeError, ValueError):
+            return True
+        return datetime.now(UTC) - last_dt >= cooldown
+
+    def mark_reminded(self, slug: str) -> None:
+        bucket = self._data.setdefault("last_remind_at", {})
+        if not isinstance(bucket, dict):
+            bucket = {}
+            self._data["last_remind_at"] = bucket
+        bucket[slug] = datetime.now(UTC).isoformat()
         self._flush()
 
     @property

--- a/acelerado/review.py
+++ b/acelerado/review.py
@@ -1,18 +1,19 @@
-"""Weekly summary + apoiadores-stale report — both posted to a private
-review channel for human approval before any public action.
+"""Editorial review primitives + weekly summary / stale-apoiadores reports.
 
 Design split:
 - **Builders** (``build_weekly_summary_text``, ``find_stale_apoiadores``)
   are pure / easy to test offline. They take data and return strings or
   member lists.
 - **Posters** (``post_weekly_summary_draft``, ``post_stale_report``)
-  are the async coroutines the bot's scheduled tasks call. They build,
-  post, and (for the weekly summary) attach a ``WeeklySummaryView`` for
-  human approval.
+  are the async coroutines the bot's scheduled tasks / admin slashes
+  call. They build, post, and (for any draft that needs approval)
+  attach an :class:`EditableDraftView` for human review.
+- **View** (:class:`EditableDraftView`) is the generic 3-button
+  Aprovar / Editar / Descartar surface — used by the weekly summary and
+  the monthly-challenge results draft (issue #37 Phase 3).
 
-The ``WeeklySummaryView`` is non-persistent (24h timeout); if the bot
-restarts mid-review, the buttons go dead — admins can re-trigger via
-``/preview-summary``.
+The view is non-persistent (24h timeout); if the bot restarts
+mid-review, the buttons go dead and the operator must re-trigger.
 """
 
 from __future__ import annotations
@@ -123,7 +124,7 @@ def format_stale_report(members: list[discord.Member]) -> str:
 # ---------------------------------------------------------------------------
 
 
-class _EditModal(ui.Modal, title="Editar resumo"):
+class _EditModal(ui.Modal):
     new_text: ui.TextInput = ui.TextInput(
         label="Texto",
         style=discord.TextStyle.paragraph,
@@ -131,8 +132,8 @@ class _EditModal(ui.Modal, title="Editar resumo"):
         max_length=3500,
     )
 
-    def __init__(self, parent: WeeklySummaryView) -> None:
-        super().__init__()
+    def __init__(self, parent: EditableDraftView, modal_title: str = "Editar texto") -> None:
+        super().__init__(title=modal_title)
         self.parent = parent
         self.new_text.default = parent.draft_text
 
@@ -144,13 +145,26 @@ class _EditModal(ui.Modal, title="Editar resumo"):
         await interaction.response.defer()
 
 
-class WeeklySummaryView(ui.View):
-    """Three-button view shown alongside the draft summary."""
+class EditableDraftView(ui.View):
+    """Generic Aprovar / Editar / Descartar surface for any review draft.
 
-    def __init__(self, draft_text: str, announce_channel_id: int) -> None:
+    ``draft_text`` is shown verbatim and editable via the modal.
+    ``target_channel_id`` is where the approved draft is sent. The
+    modal title is configurable so the surface can read sensibly for
+    different drafts (resumo semanal, resultados do desafio, …).
+    """
+
+    def __init__(
+        self,
+        draft_text: str,
+        target_channel_id: int,
+        *,
+        modal_title: str = "Editar texto",
+    ) -> None:
         super().__init__(timeout=24 * 60 * 60)  # 24h
         self.draft_text = draft_text
-        self.announce_channel_id = announce_channel_id
+        self.target_channel_id = target_channel_id
+        self.modal_title = modal_title
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         # Only mods (manage_messages) can act. discord.py auto-replies if False.
@@ -170,13 +184,13 @@ class WeeklySummaryView(ui.View):
         _button: ui.Button,
     ) -> None:
         bot = cast(commands.Bot, interaction.client)
-        announce_channel = bot.get_channel(self.announce_channel_id)
-        if not isinstance(announce_channel, discord.abc.Messageable):
+        target_channel = bot.get_channel(self.target_channel_id)
+        if not isinstance(target_channel, discord.abc.Messageable):
             await interaction.response.send_message(
-                "⚠️ Canal de anúncios não acessível.", ephemeral=True
+                "⚠️ Canal de destino não acessível.", ephemeral=True
             )
             return
-        await announce_channel.send(self.draft_text)
+        await target_channel.send(self.draft_text)
         if interaction.message is not None:
             await interaction.message.edit(content=f"✅ APROVADO\n\n{self.draft_text}", view=None)
         await interaction.response.send_message("Postado!", ephemeral=True)
@@ -188,7 +202,7 @@ class WeeklySummaryView(ui.View):
         interaction: discord.Interaction,
         _button: ui.Button,
     ) -> None:
-        await interaction.response.send_modal(_EditModal(self))
+        await interaction.response.send_modal(_EditModal(self, self.modal_title))
 
     @ui.button(label="🚫 Descartar", style=discord.ButtonStyle.danger)
     async def discard(
@@ -231,7 +245,11 @@ async def post_weekly_summary_draft(bot: commands.Bot) -> str:
             logger.warning(f"Could not fetch video {vid} for summary: {exc}")
 
     draft = build_weekly_summary_text(full_videos)
-    view = WeeklySummaryView(draft, cfg.DISCORD_ANNOUNCE_CHANNEL_ID)
+    view = EditableDraftView(
+        draft,
+        cfg.DISCORD_ANNOUNCE_CHANNEL_ID,
+        modal_title="Editar resumo",
+    )
     await review_channel.send(content=draft, view=view)
     return "✅ Rascunho postado no canal de review."
 

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -14,6 +14,7 @@ To add a new command:
 
 import logging
 import re
+from typing import cast
 
 import discord
 from discord import app_commands
@@ -187,11 +188,18 @@ async def cmd_godbolt(
     await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
-@app_commands.command(
-    name="desafio",
-    description="Mostra o desafio de performance ativo do mês",
-)
-async def cmd_desafio(interaction: discord.Interaction) -> None:
+# ---------------------------------------------------------------------------
+# /desafio group — issue #37 Phases 1–3
+#
+# Built as a group so the surface is ``/desafio status``, ``/desafio
+# resultados <slug>``, etc. Same pattern as ``/config``: the group lives
+# inside :func:`_build_desafio_group` because discord.py binds groups to
+# a tree at add time and barfs on re-registration.
+# ---------------------------------------------------------------------------
+
+
+async def _render_status(interaction: discord.Interaction) -> None:
+    """Body of ``/desafio status`` — the active challenge view."""
     from datetime import UTC, datetime
 
     from acelerado.challenges import announce as challenge_announce
@@ -260,6 +268,159 @@ async def cmd_desafio(interaction: discord.Interaction) -> None:
         inline=False,
     )
     await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+def _build_desafio_group() -> app_commands.Group:
+    """Build a fresh ``/desafio`` group bound to a single tree."""
+    from discord.ext import commands
+
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges import results as challenge_results
+    from acelerado.challenges.state import ChallengesState
+    from acelerado.env import get_env
+    from acelerado.review import EditableDraftView
+
+    group = app_commands.Group(
+        name="desafio",
+        description="Desafios mensais de performance",
+    )
+
+    @group.command(name="status", description="Mostra o desafio ativo do mês")
+    async def cmd_status(interaction: discord.Interaction) -> None:
+        await _render_status(interaction)
+
+    @group.command(
+        name="resultados",
+        description="(admin) Posta o draft de resultados do desafio no canal de review",
+    )
+    @app_commands.describe(slug="Slug do desafio (ex: 2026-05-deblur)")
+    @app_commands.default_permissions(administrator=True)
+    async def cmd_resultados(interaction: discord.Interaction, slug: str) -> None:
+        cfg = get_env()
+        if not cfg.DISCORD_REVIEW_CHANNEL_ID:
+            await interaction.response.send_message(
+                "⚠️ DISCORD_REVIEW_CHANNEL_ID não configurado.",
+                ephemeral=True,
+            )
+            return
+        if not cfg.DISCORD_CHALLENGES_CHANNEL_ID:
+            await interaction.response.send_message(
+                "⚠️ DISCORD_CHALLENGES_CHANNEL_ID não configurado — sem destino pra postar.",
+                ephemeral=True,
+            )
+            return
+
+        bot = cast(commands.Bot, interaction.client)
+        review_channel = bot.get_channel(cfg.DISCORD_REVIEW_CHANNEL_ID)
+        if not isinstance(review_channel, discord.abc.Messageable):
+            await interaction.response.send_message(
+                "⚠️ Canal de review não acessível.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            results = await challenge_github.fetch_results(
+                cfg.ACELERADO_CHALLENGES_REPO,
+                slug,
+            )
+        except challenge_github.GitHubError as exc:
+            await interaction.followup.send(
+                f"⚠️ Erro buscando results.json: `{exc}`",
+                ephemeral=True,
+            )
+            return
+
+        if results is None:
+            await interaction.followup.send(
+                f"📭 `{slug}/results.json` não existe no repo ainda.",
+                ephemeral=True,
+            )
+            return
+
+        draft = challenge_results.render_results_post(results)
+        view = EditableDraftView(
+            draft,
+            cfg.DISCORD_CHALLENGES_CHANNEL_ID,
+            modal_title="Editar resultados",
+        )
+        await review_channel.send(content=draft, view=view)
+
+        ChallengesState().mark_results_posted(slug)
+        await interaction.followup.send(
+            f"✅ Draft de **{slug}** postado em <#{cfg.DISCORD_REVIEW_CHANNEL_ID}>.",
+            ephemeral=True,
+        )
+
+    @group.command(
+        name="resultados-skip",
+        description="(admin) Para de cobrar resultados desse desafio",
+    )
+    @app_commands.describe(slug="Slug do desafio (ex: 2026-05-deblur)")
+    @app_commands.default_permissions(administrator=True)
+    async def cmd_resultados_skip(interaction: discord.Interaction, slug: str) -> None:
+        ChallengesState().mark_results_dismissed(slug)
+        await interaction.response.send_message(
+            f"✅ Reminders de **{slug}** silenciados.", ephemeral=True
+        )
+
+    @group.command(
+        name="historico",
+        description="Top-3 dos desafios passados (cache de 6h)",
+    )
+    async def cmd_historico(interaction: discord.Interaction) -> None:
+        cfg = get_env()
+        if not cfg.ACELERADO_CHALLENGES_ENABLED:
+            await interaction.response.send_message(
+                "⚠️ Desafios mensais ainda não estão habilitados.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            history, fetched_at = await challenge_github.get_cached_history(
+                cfg.ACELERADO_CHALLENGES_REPO,
+            )
+        except challenge_github.GitHubError as exc:
+            await interaction.followup.send(
+                f"⚠️ Erro lendo o histórico: `{exc}`",
+                ephemeral=True,
+            )
+            return
+
+        if not history:
+            await interaction.followup.send(
+                "📭 Ainda não há resultados publicados.", ephemeral=True
+            )
+            return
+
+        embed = discord.Embed(
+            title="🏁 Histórico de desafios",
+            color=discord.Color.dark_gold(),
+        )
+        for results in history:
+            top3 = [e for e in results.ranking if e.rank <= 3]
+            if top3:
+                lines = []
+                for entry in top3:
+                    primary_str = challenge_results.format_metric_value(
+                        results.primary_metric,
+                        entry.metrics.get(results.primary_metric, "—"),
+                    )
+                    lines.append(f"{entry.rank}º @{entry.user} — {primary_str}")
+                value = "\n".join(lines)
+            else:
+                value = "_sem submissões válidas_"
+            embed.add_field(
+                name=f"{results.slug} ({results.primary_metric})",
+                value=value,
+                inline=False,
+            )
+        embed.set_footer(text=f"Última atualização: {fetched_at.strftime('%Y-%m-%d %H:%M UTC')}")
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    return group
 
 
 @app_commands.command(name="report", description="Reportar uma mensagem aos mods")
@@ -468,5 +629,5 @@ def register_commands(
     tree.add_command(cmd_preview_summary, guild=guild)
     tree.add_command(cmd_preview_stale, guild=guild)
     tree.add_command(cmd_godbolt, guild=guild)
-    tree.add_command(cmd_desafio, guild=guild)
+    tree.add_command(_build_desafio_group(), guild=guild)
     tree.add_command(_build_config_group(), guild=guild)

--- a/acelerado/state.py
+++ b/acelerado/state.py
@@ -343,6 +343,47 @@ class AceleradoState:
         metrics.increment("challenges_announced", context=spec.slug)
         logger.info(f"Announced challenge {spec.slug}")
 
+    async def _remind_pending_results(self) -> None:
+        """Nudge the operator (in the log channel) to post results for past challenges.
+
+        A "ripe" slug is one whose ``YYYY-MM`` is strictly before the
+        current month and which is neither posted nor dismissed in the
+        challenges state. We rate-limit reminders to once per 24h per
+        slug so the log channel doesn't get spammy on a 5-minute tick.
+        """
+        cfg = get_env()
+        if not cfg.ACELERADO_CHALLENGES_ENABLED:
+            return
+
+        log_channel = self.channel_log
+        if log_channel is None:
+            return
+
+        now = datetime.now(UTC)
+        current_month = now.strftime("%Y-%m")
+
+        try:
+            slugs = await challenge_github.list_challenge_slugs(
+                cfg.ACELERADO_CHALLENGES_REPO,
+            )
+        except challenge_github.GitHubError as exc:
+            logger.warning(f"Could not list challenges for reminder: {exc}")
+            return
+
+        for slug in slugs:
+            month = challenge_github.slug_month(slug)
+            if month is None or month >= current_month:
+                continue  # active or future month — no nudge yet
+            if not self.challenges.should_remind(slug):
+                continue
+            await log_channel.send(
+                f"📋 Resultados de **{slug}** pendentes. "
+                f"Use `/desafio resultados {slug}` quando rodar os benchmarks, "
+                f"ou `/desafio resultados-skip {slug}` pra parar de avisar."
+            )
+            self.challenges.mark_reminded(slug)
+            logger.info(f"Posted results reminder for {slug}")
+
     async def event_loop(self) -> None:
         logger.info("Started event loop...")
 
@@ -352,6 +393,7 @@ class AceleradoState:
             ("upcoming_lives", self._check_upcoming_lives),
             ("videos", self._pub_new_videos),
             ("challenge_announce", self._announce_new_challenge),
+            ("challenge_results_reminder", self._remind_pending_results),
         ]
         for name, step in steps:
             try:

--- a/tests/test_challenges_github.py
+++ b/tests/test_challenges_github.py
@@ -164,6 +164,128 @@ async def test_count_open_submissions_raises_on_non_list_payload():
         await gh.count_open_submissions(REPO)
 
 
+# ---------------------------------------------------------------------------
+# Phase 3 — fetch_results / list_past_results / get_cached_history
+# ---------------------------------------------------------------------------
+
+
+RESULTS_PAYLOAD = {
+    "slug": "2026-05-deblur",
+    "primary_metric": "psnr_mean_db",
+    "direction": "max",
+    "ranking": [{"rank": 1, "user": "alice", "metrics": {"psnr_mean_db": 41.2}}],
+}
+
+
+@respx.mock
+async def test_fetch_results_returns_parsed_payload():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    respx.get(url).mock(return_value=httpx.Response(200, json=RESULTS_PAYLOAD))
+
+    results = await gh.fetch_results(REPO, "2026-05-deblur")
+    assert results is not None
+    assert results.slug == "2026-05-deblur"
+    assert results.ranking[0].user == "alice"
+
+
+@respx.mock
+async def test_fetch_results_returns_none_on_404():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-06-foo/results.json"
+    respx.get(url).mock(return_value=httpx.Response(404, text="not found"))
+    assert await gh.fetch_results(REPO, "2026-06-foo") is None
+
+
+@respx.mock
+async def test_fetch_results_raises_on_other_http_errors():
+    url = f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    respx.get(url).mock(return_value=httpx.Response(500, text="boom"))
+    with pytest.raises(gh.GitHubError, match="500"):
+        await gh.fetch_results(REPO, "2026-05-deblur")
+
+
+@respx.mock
+async def test_list_past_results_collects_only_existing_files():
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=_contents_payload())
+    )
+    # 2026-05-deblur has results, 2026-04-mandelbrot doesn't.
+    respx.get(f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json").mock(
+        return_value=httpx.Response(200, json=RESULTS_PAYLOAD)
+    )
+    respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-04-mandelbrot/results.json"
+    ).mock(return_value=httpx.Response(404, text="not yet"))
+
+    history = await gh.list_past_results(REPO)
+    assert len(history) == 1
+    assert history[0].slug == "2026-05-deblur"
+
+
+@respx.mock
+async def test_list_past_results_orders_most_recent_first():
+    contents = [
+        {"name": "2026-04-mandelbrot", "type": "dir"},
+        {"name": "2026-05-deblur", "type": "dir"},
+    ]
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=contents)
+    )
+    payload_05 = dict(RESULTS_PAYLOAD)
+    payload_04 = {
+        "slug": "2026-04-mandelbrot",
+        "primary_metric": "time_ms",
+        "direction": "min",
+        "ranking": [],
+    }
+    respx.get(f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json").mock(
+        return_value=httpx.Response(200, json=payload_05)
+    )
+    respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-04-mandelbrot/results.json"
+    ).mock(return_value=httpx.Response(200, json=payload_04))
+
+    history = await gh.list_past_results(REPO)
+    assert [r.slug for r in history] == ["2026-05-deblur", "2026-04-mandelbrot"]
+
+
+@respx.mock
+async def test_get_cached_history_returns_fresh_then_cached():
+    from datetime import timedelta
+
+    gh.clear_history_cache()
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=[{"name": "2026-05-deblur", "type": "dir"}])
+    )
+    raw_route = respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    ).mock(return_value=httpx.Response(200, json=RESULTS_PAYLOAD))
+
+    first, t1 = await gh.get_cached_history(REPO, ttl=timedelta(hours=6))
+    second, t2 = await gh.get_cached_history(REPO, ttl=timedelta(hours=6))
+    assert [r.slug for r in first] == [r.slug for r in second]
+    # Cache returned same timestamp, didn't refetch raw.
+    assert t1 == t2
+    assert raw_route.call_count == 1
+
+
+@respx.mock
+async def test_get_cached_history_refreshes_after_ttl():
+    from datetime import timedelta
+
+    gh.clear_history_cache()
+    respx.get(f"{gh.API_BASE}/repos/{REPO}/contents").mock(
+        return_value=httpx.Response(200, json=[{"name": "2026-05-deblur", "type": "dir"}])
+    )
+    raw_route = respx.get(
+        f"https://raw.githubusercontent.com/{REPO}/HEAD/2026-05-deblur/results.json"
+    ).mock(return_value=httpx.Response(200, json=RESULTS_PAYLOAD))
+
+    await gh.get_cached_history(REPO, ttl=timedelta(seconds=0))
+    await gh.get_cached_history(REPO, ttl=timedelta(seconds=0))
+    # zero TTL means every call is a miss.
+    assert raw_route.call_count == 2
+
+
 def test_slug_month_extracts_prefix():
     assert gh.slug_month("2026-05-deblur") == "2026-05"
     assert gh.slug_month("2026-12-foo-bar") == "2026-12"

--- a/tests/test_challenges_results.py
+++ b/tests/test_challenges_results.py
@@ -1,0 +1,189 @@
+"""Tests for ``acelerado.challenges.results`` — model + renderer."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from acelerado.challenges.results import (
+    format_metric_value,
+    load_results,
+    render_results_post,
+)
+
+PSNR_PAYLOAD = {
+    "slug": "2026-05-deblur",
+    "primary_metric": "psnr_mean_db",
+    "direction": "max",
+    "ranking": [
+        {
+            "rank": 1,
+            "user": "alice",
+            "language": "rust",
+            "metrics": {"psnr_mean_db": 41.2, "time_ms_per_image": 87, "peak_rss_mb": 38},
+        },
+        {
+            "rank": 2,
+            "user": "bob",
+            "language": "c",
+            "metrics": {"psnr_mean_db": 39.8, "time_ms_per_image": 102, "peak_rss_mb": 42},
+        },
+        {
+            "rank": 3,
+            "user": "carol",
+            "language": "python",
+            "metrics": {"psnr_mean_db": 35.5, "time_ms_per_image": 1500, "peak_rss_mb": 60},
+        },
+        {
+            "rank": 4,
+            "user": "dave",
+            "language": "go",
+            "metrics": {"psnr_mean_db": 30.1, "time_ms_per_image": 90, "peak_rss_mb": 45},
+        },
+    ],
+    "disqualified": [{"user": "eve", "reason": "estourou peak_rss_mb cap"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_load_results_parses_full_payload():
+    results = load_results(PSNR_PAYLOAD)
+    assert results.slug == "2026-05-deblur"
+    assert results.primary_metric == "psnr_mean_db"
+    assert len(results.ranking) == 4
+    assert results.ranking[0].user == "alice"
+    assert results.ranking[0].metrics["psnr_mean_db"] == 41.2
+    assert len(results.disqualified) == 1
+
+
+def test_load_results_preserves_unknown_fields():
+    payload = dict(PSNR_PAYLOAD, hardware="ryzen 9 5950x")
+    results = load_results(payload)
+    assert results.model_extra is not None
+    assert results.model_extra.get("hardware") == "ryzen 9 5950x"
+
+
+def test_load_results_rejects_missing_required():
+    bad = {k: v for k, v in PSNR_PAYLOAD.items() if k != "primary_metric"}
+    with pytest.raises(ValidationError):
+        load_results(bad)
+
+
+def test_load_results_empty_ranking_ok():
+    minimal = {"slug": "2026-06-foo", "primary_metric": "time_ms", "direction": "min"}
+    results = load_results(minimal)
+    assert results.ranking == []
+    assert results.disqualified == []
+
+
+# ---------------------------------------------------------------------------
+# format_metric_value
+# ---------------------------------------------------------------------------
+
+
+def test_format_time_ms_under_one_second():
+    assert format_metric_value("time_ms", 87) == "87 ms"
+
+
+def test_format_time_ms_seconds():
+    assert format_metric_value("time_ms", 1500) == "1.50 s"
+
+
+def test_format_time_ms_per_image_appends_per_img():
+    assert format_metric_value("time_ms_per_image", 87) == "87 ms/img"
+    assert format_metric_value("time_ms_per_image", 1500) == "1.50 s/img"
+
+
+def test_format_memory_mb():
+    assert format_metric_value("peak_rss_mb", 142) == "142 MB"
+    assert format_metric_value("disk_write_mb", 15) == "15 MB"
+
+
+def test_format_bytes_humanizes():
+    assert format_metric_value("binary_size_bytes", 312) == "312 B"
+    assert format_metric_value("binary_size_bytes", 2048) == "2.0 KB"
+    assert format_metric_value("binary_size_bytes", 2_400_000) == "2.40 MB"
+    assert format_metric_value("code_size_bytes", 312) == "312 B"
+
+
+def test_format_psnr_db():
+    assert format_metric_value("psnr_mean_db", 41.2) == "41.20 dB"
+
+
+def test_format_unknown_metric_falls_back_to_str():
+    assert format_metric_value("custom_metric", "weird-value") == "weird-value"
+
+
+def test_format_handles_non_numeric_gracefully():
+    # If results.json has a buggy value, we degrade to str() rather than raise.
+    assert format_metric_value("time_ms", "not-a-number") == "not-a-number"
+
+
+# ---------------------------------------------------------------------------
+# render_results_post
+# ---------------------------------------------------------------------------
+
+
+def test_render_includes_top3_with_podium():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "🥇" in post
+    assert "🥈" in post
+    assert "🥉" in post
+    assert "@alice" in post
+    assert "41.20 dB" in post
+
+
+def test_render_top3_has_secondary_line_with_lang_and_metrics():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    # alice's secondary: time + memory + language
+    assert "87 ms/img" in post
+    assert "38 MB" in post
+    assert "rust" in post
+
+
+def test_render_collapses_ranks_4plus_into_short_list():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "Demais participantes" in post
+    assert "@dave" in post
+
+
+def test_render_lists_disqualified_at_end():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "Desclassificados" in post
+    assert "@eve" in post
+    assert "estourou peak_rss_mb cap" in post
+
+
+def test_render_handles_empty_ranking():
+    results = load_results({"slug": "2026-06-foo", "primary_metric": "time_ms", "direction": "min"})
+    post = render_results_post(results)
+    assert "Sem submissões válidas" in post
+    assert "Desclassificados" not in post  # no DQ section when empty
+
+
+def test_render_handles_missing_secondary_metrics():
+    """Entry with only the primary metric — no secondary line should appear."""
+    payload = {
+        "slug": "2026-07-bar",
+        "primary_metric": "time_ms",
+        "direction": "min",
+        "ranking": [{"rank": 1, "user": "alice", "metrics": {"time_ms": 500}}],
+    }
+    results = load_results(payload)
+    post = render_results_post(results)
+    assert "@alice" in post
+    assert "500 ms" in post
+
+
+def test_render_includes_slug_in_header():
+    results = load_results(PSNR_PAYLOAD)
+    post = render_results_post(results)
+    assert "2026-05-deblur" in post

--- a/tests/test_challenges_state.py
+++ b/tests/test_challenges_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from acelerado.challenges.state import ChallengesState
@@ -57,3 +58,90 @@ def test_non_object_root_starts_fresh(tmp_path: Path):
     path.write_text(json.dumps([1, 2, 3]))
     state = ChallengesState(path)
     assert state.raw == {}
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — results posted/dismissed + reminder rate-limit
+# ---------------------------------------------------------------------------
+
+
+def test_mark_results_posted_persists(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_results_posted("2026-05-deblur")
+
+    assert state.is_results_posted("2026-05-deblur")
+    on_disk = json.loads(path.read_text())
+    assert on_disk["results_posted"] == ["2026-05-deblur"]
+
+
+def test_mark_results_dismissed_persists(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_results_dismissed("2026-04-mandelbrot")
+
+    assert state.is_results_dismissed("2026-04-mandelbrot")
+    on_disk = json.loads(path.read_text())
+    assert on_disk["results_dismissed"] == ["2026-04-mandelbrot"]
+
+
+def test_mark_idempotent(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_results_posted("x")
+    state.mark_results_posted("x")
+    state.mark_results_dismissed("y")
+    state.mark_results_dismissed("y")
+    assert state._list("results_posted") == ["x"]
+    assert state._list("results_dismissed") == ["y"]
+
+
+def test_should_remind_true_when_never_reminded(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    assert state.should_remind("2026-05-deblur") is True
+
+
+def test_should_remind_false_when_posted(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_results_posted("2026-05-deblur")
+    assert state.should_remind("2026-05-deblur") is False
+
+
+def test_should_remind_false_when_dismissed(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_results_dismissed("2026-05-deblur")
+    assert state.should_remind("2026-05-deblur") is False
+
+
+def test_should_remind_respects_cooldown(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state.mark_reminded("2026-05-deblur")
+    # Default cooldown is 24h — fresh reminder shouldn't fire.
+    assert state.should_remind("2026-05-deblur") is False
+
+
+def test_should_remind_after_cooldown_elapsed(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    # Backdate the timestamp by 25h to simulate elapsed cooldown.
+    past = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+    state._data["last_remind_at"] = {"2026-05-deblur": past}
+    state._flush()
+    assert state.should_remind("2026-05-deblur") is True
+
+
+def test_should_remind_handles_corrupt_timestamp(tmp_path: Path):
+    state = ChallengesState(tmp_path / "state.json")
+    state._data["last_remind_at"] = {"2026-05-deblur": "not-a-date"}
+    # Garbled value should NOT mute the reminder forever — we just ignore it.
+    assert state.should_remind("2026-05-deblur") is True
+
+
+def test_mark_reminded_persists(tmp_path: Path):
+    path = tmp_path / "state.json"
+    state = ChallengesState(path)
+    state.mark_reminded("2026-05-deblur")
+
+    on_disk = json.loads(path.read_text())
+    assert "2026-05-deblur" in on_disk["last_remind_at"]
+    # Should round-trip into a parseable datetime.
+    parsed = datetime.fromisoformat(on_disk["last_remind_at"]["2026-05-deblur"])
+    assert parsed.tzinfo is not None

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -412,19 +412,33 @@ async def test_config_unset_reverts_to_fallback(chdir_tmp):
 # ---------------------------------------------------------------------------
 
 
-def test_register_desafio_command():
+def test_register_desafio_group():
     tree = _build_tree()
     guild = discord.Object(id=1)
     register_commands(tree, guild=guild)
     cmd = tree.get_command("desafio", guild=guild)
     assert cmd is not None
-    assert cmd.name == "desafio"
+    assert isinstance(cmd, app_commands.Group)
+    sub_names = {c.name for c in cmd.commands}
+    assert sub_names == {"status", "resultados", "resultados-skip", "historico"}
+
+
+def _get_desafio_subcommand(name: str):
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    group = tree.get_command("desafio", guild=guild)
+    assert isinstance(group, app_commands.Group)
+    for cmd in group.commands:
+        if cmd.name == name:
+            return cmd
+    raise AssertionError(f"subcommand {name!r} not registered")
 
 
 async def test_desafio_responds_when_disabled(monkeypatch):
     monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -432,7 +446,7 @@ async def test_desafio_responds_when_disabled(monkeypatch):
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     interaction.response.send_message.assert_awaited_once()
     msg = interaction.response.send_message.await_args.args[0]
     assert "não estão habilitados" in msg.lower() or "habilitados" in msg.lower()
@@ -443,7 +457,7 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     from acelerado.challenges import github as challenge_github
     from acelerado.challenges.spec import load_spec
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -473,7 +487,7 @@ async def test_desafio_returns_embed_when_active(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     interaction.response.defer.assert_awaited_once()
     interaction.followup.send.assert_awaited_once()
     embed = interaction.followup.send.await_args.kwargs.get("embed")
@@ -493,7 +507,7 @@ async def test_desafio_renders_when_submission_count_fails(monkeypatch):
     from acelerado.challenges import github as challenge_github
     from acelerado.challenges.spec import load_spec
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -523,7 +537,7 @@ async def test_desafio_renders_when_submission_count_fails(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     embed = interaction.followup.send.await_args.kwargs.get("embed")
     assert embed is not None
     submissions_field = next((f for f in embed.fields if f.name == "Submissões"), None)
@@ -535,7 +549,7 @@ async def test_desafio_handles_missing_challenge(monkeypatch):
     monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
     from acelerado.challenges import github as challenge_github
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -550,7 +564,7 @@ async def test_desafio_handles_missing_challenge(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     msg = interaction.followup.send.await_args.args[0]
     assert "Nenhum desafio" in msg
 
@@ -559,7 +573,7 @@ async def test_desafio_reports_github_errors(monkeypatch):
     monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
     from acelerado.challenges import github as challenge_github
     from acelerado.config import reload_settings
-    from acelerado.slash import cmd_desafio
+    from acelerado.slash import _render_status
 
     reload_settings()
 
@@ -574,10 +588,216 @@ async def test_desafio_reports_github_errors(monkeypatch):
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
 
-    await cmd_desafio.callback(interaction)
+    await _render_status(interaction)
     msg = interaction.followup.send.await_args.args[0]
     assert "GitHub" in msg
     assert "404" in msg
+
+
+# ---------------------------------------------------------------------------
+# /desafio resultados / resultados-skip / historico (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+def _admin_interaction_with_bot(bot):
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = bot
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+async def test_desafio_resultados_warns_when_review_channel_unset(monkeypatch):
+    monkeypatch.delenv("DISCORD_REVIEW_CHANNEL_ID", raising=False)
+    monkeypatch.setenv("DISCORD_CHALLENGES_CHANNEL_ID", "999")
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "REVIEW_CHANNEL_ID" in msg
+
+
+async def test_desafio_resultados_warns_when_target_channel_unset(monkeypatch):
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "555")
+    monkeypatch.delenv("DISCORD_CHALLENGES_CHANNEL_ID", raising=False)
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "CHALLENGES_CHANNEL_ID" in msg
+
+
+async def test_desafio_resultados_404_returns_friendly_message(monkeypatch):
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "555")
+    monkeypatch.setenv("DISCORD_CHALLENGES_CHANNEL_ID", "999")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    async def fake_fetch(repo, slug, token=None):
+        return None
+
+    monkeypatch.setattr(challenge_github, "fetch_results", fake_fetch)
+
+    fake_review = MagicMock(spec=discord.TextChannel)
+    fake_review.send = AsyncMock()
+    bot = MagicMock()
+    bot.get_channel.side_effect = lambda cid: fake_review if cid == 555 else None
+
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(bot)
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    msg = interaction.followup.send.await_args.args[0]
+    assert "não existe" in msg
+    fake_review.send.assert_not_awaited()
+
+
+async def test_desafio_resultados_posts_draft_with_view(monkeypatch, chdir_tmp):
+    monkeypatch.setenv("DISCORD_REVIEW_CHANNEL_ID", "555")
+    monkeypatch.setenv("DISCORD_CHALLENGES_CHANNEL_ID", "999")
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges.results import load_results
+    from acelerado.challenges.state import ChallengesState
+    from acelerado.config import reload_settings
+    from acelerado.review import EditableDraftView
+
+    reload_settings()
+
+    results = load_results(
+        {
+            "slug": "2026-05-deblur",
+            "primary_metric": "psnr_mean_db",
+            "direction": "max",
+            "ranking": [{"rank": 1, "user": "alice", "metrics": {"psnr_mean_db": 41.2}}],
+        }
+    )
+
+    async def fake_fetch(repo, slug, token=None):
+        return results
+
+    monkeypatch.setattr(challenge_github, "fetch_results", fake_fetch)
+
+    fake_review = MagicMock(spec=discord.TextChannel)
+    fake_review.send = AsyncMock()
+    bot = MagicMock()
+    bot.get_channel.side_effect = lambda cid: fake_review if cid == 555 else None
+
+    cmd = _get_desafio_subcommand("resultados")
+    interaction = _admin_interaction_with_bot(bot)
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    fake_review.send.assert_awaited_once()
+    kwargs = fake_review.send.await_args.kwargs
+    assert "@alice" in kwargs.get("content", "")
+    assert isinstance(kwargs.get("view"), EditableDraftView)
+    assert kwargs["view"].target_channel_id == 999
+
+    # State now flags the slug as posted, killing the reminder.
+    assert ChallengesState().is_results_posted("2026-05-deblur")
+
+
+async def test_desafio_resultados_skip_marks_dismissed(monkeypatch, chdir_tmp):
+    from acelerado.challenges.state import ChallengesState
+
+    cmd = _get_desafio_subcommand("resultados-skip")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction, slug="2026-05-deblur")
+
+    assert ChallengesState().is_results_dismissed("2026-05-deblur")
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "silenciados" in msg
+
+
+async def test_desafio_historico_renders_embed(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from datetime import UTC, datetime
+
+    from acelerado.challenges import github as challenge_github
+    from acelerado.challenges.results import load_results
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    challenge_github.clear_history_cache()
+
+    history = [
+        load_results(
+            {
+                "slug": "2026-05-deblur",
+                "primary_metric": "psnr_mean_db",
+                "direction": "max",
+                "ranking": [
+                    {"rank": 1, "user": "alice", "metrics": {"psnr_mean_db": 41.2}},
+                    {"rank": 2, "user": "bob", "metrics": {"psnr_mean_db": 39.8}},
+                ],
+            }
+        ),
+    ]
+    fixed_now = datetime(2026, 6, 5, 14, 23, tzinfo=UTC)
+
+    async def fake_get(repo, ttl=None, token=None):
+        return history, fixed_now
+
+    monkeypatch.setattr(challenge_github, "get_cached_history", fake_get)
+
+    cmd = _get_desafio_subcommand("historico")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction)
+
+    embed = interaction.followup.send.await_args.kwargs.get("embed")
+    assert embed is not None
+    field = embed.fields[0]
+    assert "2026-05-deblur" in field.name
+    assert "@alice" in (field.value or "")
+    # Footer carries the freshness timestamp.
+    assert "2026-06-05" in (embed.footer.text or "")
+
+
+async def test_desafio_historico_blocked_when_disabled(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_desafio_subcommand("historico")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+
+
+async def test_desafio_historico_handles_empty(monkeypatch):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "true")
+    from datetime import UTC, datetime
+
+    from acelerado.challenges import github as challenge_github
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    challenge_github.clear_history_cache()
+
+    async def fake_get(repo, ttl=None, token=None):
+        return [], datetime.now(UTC)
+
+    monkeypatch.setattr(challenge_github, "get_cached_history", fake_get)
+
+    cmd = _get_desafio_subcommand("historico")
+    interaction = _admin_interaction_with_bot(MagicMock())
+    await cmd.callback(interaction)
+
+    msg = interaction.followup.send.await_args.args[0]
+    assert "Ainda não há resultados" in msg
 
 
 async def test_update_command_ok_schedules_restart(monkeypatch):

--- a/tests/test_state_challenges.py
+++ b/tests/test_state_challenges.py
@@ -195,3 +195,84 @@ async def test_announce_persists_across_state_instances(
     fresh = state_mod.AceleradoState(fake_bot)
     await fresh._announce_new_challenge()
     assert challenges_channel.send.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — _remind_pending_results
+# ---------------------------------------------------------------------------
+
+
+async def _patch_slugs(monkeypatch, slugs):
+    async def fake_list(repo, token=None):
+        return list(slugs)
+
+    monkeypatch.setattr(challenge_github, "list_challenge_slugs", fake_list)
+
+
+async def test_reminder_skipped_when_disabled(state_with_challenges, monkeypatch, fake_guild):
+    monkeypatch.setenv("ACELERADO_CHALLENGES_ENABLED", "false")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()
+
+
+async def test_reminder_posts_for_past_month_slug(state_with_challenges, monkeypatch, fake_guild):
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur", "2026-06-active"])
+
+    await state_with_challenges._remind_pending_results()
+
+    fake_guild._log.send.assert_awaited_once()
+    msg = fake_guild._log.send.await_args.args[0]
+    # Active month (2026-06) should NOT be nudged.
+    assert "2026-05-deblur" in msg
+    assert "2026-06-active" not in msg
+
+
+async def test_reminder_skips_slugs_already_posted(state_with_challenges, monkeypatch, fake_guild):
+    state_with_challenges.challenges.mark_results_posted("2026-05-deblur")
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()
+
+
+async def test_reminder_skips_slugs_dismissed(state_with_challenges, monkeypatch, fake_guild):
+    state_with_challenges.challenges.mark_results_dismissed("2026-05-deblur")
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()
+
+
+async def test_reminder_rate_limited_to_24h(state_with_challenges, monkeypatch, fake_guild):
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+    await _patch_slugs(monkeypatch, ["2026-05-deblur"])
+
+    await state_with_challenges._remind_pending_results()
+    await state_with_challenges._remind_pending_results()
+
+    # Two ticks within the cooldown window — only one reminder.
+    assert fake_guild._log.send.await_count == 1
+
+
+async def test_reminder_swallows_github_errors(state_with_challenges, monkeypatch, fake_guild):
+    _patch_now(monkeypatch, datetime(2026, 6, 5, 12, tzinfo=UTC))
+
+    async def boom(repo, token=None):
+        raise challenge_github.GitHubError("rate limited")
+
+    monkeypatch.setattr(challenge_github, "list_challenge_slugs", boom)
+
+    # Must NOT raise — the tick wraps each step in try/except, but we
+    # still want this step to handle expected errors locally.
+    await state_with_challenges._remind_pending_results()
+    fake_guild._log.send.assert_not_awaited()


### PR DESCRIPTION
Stack em cima de #38. Implementa a Fase 3 da issue #37: pipeline manual de resultados, reminders mensais até ação, e histórico cacheado. Sem step automático que posta o draft sozinho — você dispara via slash quando rodar os benchmarks.

## Summary

### Comando manual de resultados

- `/desafio resultados <slug>` (admin) busca `<slug>/results.json` no repo, renderiza um draft Markdown consciente da métrica primária, e posta no `DISCORD_REVIEW_CHANNEL_ID` com a `View` editorial (Aprovar → posta no `DISCORD_CHALLENGES_CHANNEL_ID`; Editar → modal; Descartar → arquiva).
- `/desafio resultados-skip <slug>` (admin) marca o slug como dismissed e silencia o reminder.

### Reminder mensal (tick)

- Step novo `_remind_pending_results` percorre todos os slugs do repo. Para cada um cujo `YYYY-MM` é estritamente anterior ao mês corrente E não está em `results_posted` nem em `results_dismissed`, posta um lembrete no **canal de log**, rate-limited a 1×/24h por slug:
  > 📋 Resultados de **2026-05-deblur** pendentes. Use \`/desafio resultados 2026-05-deblur\` quando rodar os benchmarks, ou \`/desafio resultados-skip 2026-05-deblur\` pra parar de avisar.

### Histórico

- `/desafio historico` (público) mostra top-3 de cada desafio com resultados publicados, com cache de 6h em memória. Footer do embed: *"Última atualização: …"*.
- O cache vive em `challenges/github.py` como dict + `clear_history_cache()` (test helper).

### Renderer consciente da métrica

- Novo `acelerado/challenges/results.py` com pydantic \`Results\` (\`extra=\"allow\"\`, espelha a postura do \`Spec\` — métricas variam por desafio).
- \`format_metric_value(metric, value)\` cobre métricas conhecidas (\`time_ms\` / \`time_ms_per_image\` com break em 1s, \`peak_rss_mb\`, \`disk_write_mb\`, \`binary_size_bytes\` / \`code_size_bytes\` humanizados, \`psnr_mean_db\`). Métricas desconhecidas: \`str(value)\` — não quebra com schema novo.
- \`render_results_post(results)\` produz pódio (top-3 com linha secundária de stats + linguagem) + lista compacta para ranks 4+ + bloco de desclassificados.

### /desafio vira slash group

\`/desafio\` agora é um group:

| Subcomando | Acesso | Função |
|---|---|---|
| \`status\` | público | Antigo \`/desafio\` flat: desafio do mês + contagem de PRs. |
| \`resultados <slug>\` | admin | Posta draft no canal de review. |
| \`resultados-skip <slug>\` | admin | Silencia reminders. |
| \`historico\` | público | Top-3 dos desafios passados (cache 6h). |

### Refator: \`WeeklySummaryView\` → \`EditableDraftView\`

A View de aprovação editorial era específica do resumo semanal mas a lógica é genérica (\`(draft_text, target_channel_id, modal_title)\`). Refatorada para ser reusada por qualquer draft. \`post_weekly_summary_draft\` agora usa \`EditableDraftView(modal_title=\"Editar resumo\")\`. Todos os 15 testes existentes passam sem mudança.

## State adições

\`challenges_state.json\` ganha 3 chaves:
- \`results_posted: list[slug]\` — slugs cujo draft já foi enviado pra review.
- \`results_dismissed: list[slug]\` — slugs onde você mandou parar de cobrar.
- \`last_remind_at: dict[slug, ISO]\` — rate-limit do reminder.

## Test plan

- [x] \`uv run pytest\` — **343 passam** (50 novos: results model + render + format helpers; fetch_results / list_past_results / get_cached_history via respx; state helpers + cooldown semantics; reminder step gating; 7 novos cobrindo subcomandos do \`/desafio\`).
- [x] \`uv run ruff check\` + \`ruff format --check\` — limpos.
- [x] \`uv run mypy acelerado\` — limpo.
- [ ] Smoke manual com \`results.json\` real no repo de desafios:
  - [ ] \`/desafio resultados 2026-05-deblur\` posta draft em review.
  - [ ] Aprovar empurra o post pro canal de desafios.
  - [ ] \`/desafio historico\` lista o desafio com top-3.
  - [ ] Reminder não dispara mais pra esse slug após posted.
- [ ] Smoke do reminder: forçar slug-no-passado sem flags, ver lembrete no log channel; rodar \`/desafio resultados-skip\`, conferir silêncio.

Refs #37 (Fase 3 completa). Não bloqueia em #36 — a infra de View já estava no \`review.py\` shipado anteriormente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)