### PR TITLE
feat(youtube): renew OAuth token via /token Discord slash

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -24,3 +24,8 @@ YOUTUBE_API_KEY=sua-api-key-aqui
 # ----- Opcional -----
 # Nível de log: DEBUG, INFO, WARNING, ERROR. Default: INFO.
 # ACELERADO_LOG_LEVEL=INFO
+
+# Discord user ID autorizado a renovar o token YouTube via /token renew-*.
+# 0 (default) desabilita essas slash commands. Ative o Developer Mode no
+# Discord, clique-direito no seu nome → "Copiar ID do usuário".
+# DISCORD_OWNER_ID=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ token.pickle      # cached OAuth user token
 `AceleradoBot.setup_hook` calls `event_loop_task.change_interval(seconds=ACELERADO_TICK_SECONDS)` (default 300) and starts the loop. Its `before_loop` waits for the gateway-ready signal, then constructs `AceleradoState` once. Each tick calls `state.event_loop()`, which iterates a `[(name, step), …]` list and wraps each step in try/except → `state.report_error(name, exc)` (logs locally + posts to Discord log channel, 10-min cooldown).
 
 1. **`check_members_apoiadores`** — for **every** role whose name contains `"YouTube Member"` (so all tiers, not just the first match), ensure each member also has the `Registradores` role; if added, post a welcome in the `chat-registradores` channel. Members appearing in multiple tiers are deduped via a `seen` id set.
-2. **`check_expiration`** — if the YouTube OAuth token expires in <24h, post a renewal reminder to the log channel (rate-limited to once/hour).
+2. **`check_expiration`** — if the YouTube OAuth token expires in <24h, post a renewal reminder to the log channel (rate-limited to once/hour). Distinguishes already-expired (negative time-to-expire → "expirou há Ns") from soon-to-expire ("expira em Ns") and points the operator at `/token renew-start`.
 3. **`_check_upcoming_lives`** — poll for scheduled livestreams and send a "live em N min" reminder when one falls inside `ACELERADO_LIVE_REMINDER_MINUTES`. Internally throttled by `ACELERADO_UPCOMING_LIVES_INTERVAL_SECONDS` (default 3600s) because `youtube.search.list` costs **100 quota units** per call vs. 1 for everything else — running it on every 5-min tick exceeds the default 10k/day quota by ~3x. Throttle is in-memory (`AceleradoState.last_upcoming_lives_check`); first tick after process start always runs.
 4. **Video announcing** — fetch the latest 10 uploads, diff against `published.txt`, and announce new ones in the announce channel with `@everyone`. Filtering rules (`should_announce_video`):
    - Skip if non-public (unlisted/private).
@@ -75,7 +75,7 @@ token.pickle      # cached OAuth user token
 
 Required: `DISCORD_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_ANNOUNCE_CHANNEL_ID`, `DISCORD_LOG_CHANNEL_ID`, `YOUTUBE_CHANNEL_ID`, `YOUTUBE_API_KEY`.
 
-Optional: `ACELERADO_TICK_SECONDS` (loop period, default `300`), `ACELERADO_LOG_LEVEL` (`DEBUG`/`INFO`/…, default `INFO`), `ACELERADO_UPCOMING_LIVES_INTERVAL_SECONDS` (upcoming-lives poll cadence, default `3600` — see Runtime behavior #3 for the quota math).
+Optional: `ACELERADO_TICK_SECONDS` (loop period, default `300`), `ACELERADO_LOG_LEVEL` (`DEBUG`/`INFO`/…, default `INFO`), `ACELERADO_UPCOMING_LIVES_INTERVAL_SECONDS` (upcoming-lives poll cadence, default `3600` — see Runtime behavior #3 for the quota math), `DISCORD_OWNER_ID` (Discord user ID allowed to run `/token renew-start` and `/token renew-finish`; default `0` keeps these commands disabled).
 
 Plus `credentials.json` (Google OAuth client). First run opens a browser for consent; the resulting token is cached to `token.pickle`.
 
@@ -117,7 +117,7 @@ The token-expiry math used `datetime.now()` (naive local) against `Credentials.e
 - User-facing strings (Discord messages, role names) are in **Portuguese** — keep that when editing.
 - Hardcoded role/channel names live in `state.py` (`ROLE_NAME_APOIADORES = "Registradores"`, `CHAT_MSG_ADD = "chat-registradores"`); the YouTube member role is matched by substring `"YouTube Member"`.
 - `published.txt` is the source of truth for "already announced". It's seeded on first run from the latest 20 uploads if missing — don't delete it on a live deployment or you'll re-announce.
-- The OAuth token must be refreshed periodically; the bot itself only *warns* about expiry, it does not auto-renew the consent flow.
+- The OAuth token must be refreshed periodically; the bot itself only *warns* about expiry, it does not auto-renew the consent flow. Two ways to renew: `acelerado refresh-token` from the host (browser-based local-server flow), or `/token renew-start` + `/token renew-finish <redirect_url>` from Discord (DM with the auth URL → user pastes the loopback redirect URL back). The Discord flow is owner-gated by `DISCORD_OWNER_ID` and parks the pending `Flow` in memory for 10 min, with CSRF-state validation on completion. The previous `token.pickle` is renamed to `token.pickle.old` before writing the new one.
 - The YouTube client and upload-playlist ID are lazy-initialized via `@lru_cache` in `youtube.py` — first call triggers OAuth and the channel lookup.
 - Slash commands live in `acelerado/slash.py`. `register_commands(tree, guild=...)` is called from `bot.setup_hook` and pushed via `tree.sync(guild=...)` — guild-scoped so changes propagate instantly. To add a new slash command: define it with `@app_commands.command(...)` in `slash.py`, add `tree.add_command(new_cmd, guild=guild)` inside `register_commands`, add a registration test in `tests/test_slash.py`. The bot is otherwise event-driven (no message-prefixed commands).
 

--- a/acelerado/env.py
+++ b/acelerado/env.py
@@ -21,6 +21,13 @@ class EnvCfg(BaseSettings):
     YOUTUBE_API_KEY: str
     DISCORD_GUILD_ID: int
 
+    # Discord user ID allowed to run sensitive owner-only slash commands
+    # (`/token renew-start` etc.). 0 disables them — they refuse with a
+    # warning instead of going through. Kept separate from
+    # `default_permissions(administrator=True)` because token rotation
+    # is a stricter gate than "anyone with Manage Server".
+    DISCORD_OWNER_ID: int = 0
+
     # How often the periodic job runs. 300s is the production default; dropping
     # this in dev lets you exercise the loop faster.
     ACELERADO_TICK_SECONDS: int = 300

--- a/acelerado/slash.py
+++ b/acelerado/slash.py
@@ -376,6 +376,111 @@ def _build_config_group() -> app_commands.Group:
     return group
 
 
+# ---------------------------------------------------------------------------
+# /token — owner-only YouTube OAuth renewal
+# ---------------------------------------------------------------------------
+#
+# The two-step "DM the auth URL → paste the redirect URL back" flow keeps
+# the auth code out of any guild channel. Both subcommands gate on
+# ``DISCORD_OWNER_ID`` (not just ``Manage Server``), since rotating the
+# YouTube token is a stricter action than the other admin slashes.
+
+
+def _is_owner(interaction: discord.Interaction) -> bool:
+    from acelerado.env import get_env
+
+    owner_id = get_env().DISCORD_OWNER_ID
+    return owner_id != 0 and interaction.user.id == owner_id
+
+
+def _build_token_group() -> app_commands.Group:
+    """Build a fresh ``/token`` group bound to a single tree."""
+    group = app_commands.Group(
+        name="token",
+        description="(dono) Renovar o token OAuth do YouTube",
+    )
+
+    @group.command(
+        name="renew-start",
+        description="Inicia o fluxo de renovação — DM com o link do Google",
+    )
+    async def cmd_token_renew_start(interaction: discord.Interaction) -> None:
+        from acelerado import youtube
+
+        if not _is_owner(interaction):
+            await interaction.response.send_message(
+                "⚠️ Só o dono (`DISCORD_OWNER_ID`) pode renovar o token.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            url = youtube.start_oauth_flow(interaction.user.id)
+        except FileNotFoundError as exc:
+            await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+            return
+
+        try:
+            dm = await interaction.user.create_dm()
+            await dm.send(
+                "🔑 **Renovação do token YouTube**\n"
+                f"1. Abra: {url}\n"
+                "2. Aprove o consentimento na conta certa.\n"
+                "3. Você será redirecionado pra `http://localhost/...` — "
+                "a página *vai* falhar (esperado).\n"
+                "4. Copie a URL inteira da barra de endereços e cole em "
+                "`/token renew-finish`.\n"
+                f"⏱️ {youtube.OAUTH_PENDING_TTL_SECONDS // 60} min antes do flow expirar."
+            )
+        except discord.Forbidden:
+            await interaction.response.send_message(
+                "❌ Não consegui enviar DM. Habilite DM de membros do servidor.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            "✅ Verifique seu DM e siga as instruções.",
+            ephemeral=True,
+        )
+
+    @group.command(
+        name="renew-finish",
+        description="Cole a URL completa do redirect (resposta privada)",
+    )
+    @app_commands.describe(
+        redirect_url="URL completa começando com http://localhost/?state=...&code=..."
+    )
+    async def cmd_token_renew_finish(
+        interaction: discord.Interaction,
+        redirect_url: str,
+    ) -> None:
+        import asyncio
+
+        from acelerado import youtube
+
+        if not _is_owner(interaction):
+            await interaction.response.send_message(
+                "⚠️ Só o dono (`DISCORD_OWNER_ID`) pode renovar o token.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            await asyncio.to_thread(youtube.complete_oauth_flow, interaction.user.id, redirect_url)
+        except (LookupError, ValueError) as exc:
+            await interaction.followup.send(f"❌ {exc}", ephemeral=True)
+            return
+
+        await interaction.followup.send(
+            "✅ Token renovado. Backup do anterior em `token.pickle.old`.",
+            ephemeral=True,
+        )
+
+    return group
+
+
 def register_commands(
     tree: app_commands.CommandTree,
     guild: discord.abc.Snowflake | None = None,
@@ -395,3 +500,4 @@ def register_commands(
     tree.add_command(cmd_preview_stale, guild=guild)
     tree.add_command(cmd_godbolt, guild=guild)
     tree.add_command(_build_config_group(), guild=guild)
+    tree.add_command(_build_token_group(), guild=guild)

--- a/acelerado/state.py
+++ b/acelerado/state.py
@@ -165,15 +165,19 @@ class AceleradoState:
 
         self.last_msg_expiry = datetime.now(UTC)
         expiry_date = youtube.get_token_expiration_date()
+        if expiration_time < 0:
+            head = f"⚠️ Token YouTube **expirou** há {int(-expiration_time)}s (em {expiry_date})."
+            log_msg = f"Token expired {int(-expiration_time)}s ago. Renew it."
+        else:
+            head = f"⚠️ Token YouTube expira em {int(expiration_time)}s (em {expiry_date})."
+            log_msg = f"Token expires in {int(expiration_time)}s. Renew it."
+        hint = "Renove com `/token renew-start` (DM com o link do Google)."
         channel = self.channel_log
         if channel is None:
             logger.warning("Log channel disappeared from cache; skipping warning")
         else:
-            await channel.send(
-                f"Renew your Token! It will expire in {int(expiration_time)} seconds "
-                f"(at {expiry_date})."
-            )
-        logger.warning(f"Your token will expire in {int(expiration_time)} seconds. Renew it.")
+            await channel.send(f"{head}\n{hint}")
+        logger.warning(log_msg)
 
     # ------------------------------------------------------------------
     # YouTube Member role sync — walks *all* tiers, not just the first.

--- a/acelerado/youtube.py
+++ b/acelerado/youtube.py
@@ -1,13 +1,15 @@
 import json
 import logging
 import pickle
+import time
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
+from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 from googleapiclient.discovery import build
 
 from acelerado.env import get_env
@@ -17,6 +19,19 @@ logger = logging.getLogger(__name__)
 SCOPES = ["https://www.googleapis.com/auth/youtube.readonly"]
 TOKEN_PATH = Path("token.pickle")
 CREDENTIALS_PATH = Path("credentials.json")
+
+# Redirect URI for the Discord-driven renewal flow. Google deprecated true
+# OOB (`urn:ietf:wg:oauth:2.0:oob`) in Oct 2022, so we use loopback — the
+# user's browser hits an unreachable URL after consent and they paste the
+# whole address back. Must be present in the OAuth client's allowed
+# redirect URIs (installed-app clients ship with `http://localhost`).
+OAUTH_REDIRECT_URI = "http://localhost"
+
+# Pending Discord-initiated flows live in memory only — keyed by Discord
+# user ID, valued (Flow, expected_state, expires_at_unix). Lost on bot
+# restart; user just re-runs `/token renew-start`.
+OAUTH_PENDING_TTL_SECONDS = 600
+_PENDING_FLOWS: dict[int, tuple[Flow, str, float]] = {}
 
 
 def get_creds() -> Credentials:
@@ -35,6 +50,79 @@ def get_creds() -> Credentials:
         with TOKEN_PATH.open("wb") as token:
             pickle.dump(creds.to_json(), token)
     return creds
+
+
+def _prune_expired_pending_flows() -> None:
+    now = time.time()
+    expired = [uid for uid, (_, _, exp) in _PENDING_FLOWS.items() if exp < now]
+    for uid in expired:
+        _PENDING_FLOWS.pop(uid, None)
+
+
+def start_oauth_flow(user_id: int) -> str:
+    """Begin a Discord-initiated OAuth consent and return the auth URL.
+
+    The pending :class:`Flow` is parked in memory keyed by ``user_id`` so
+    :func:`complete_oauth_flow` can pick it up. Google generates a
+    CSRF-protected ``state`` token which we validate on completion.
+    Raises :class:`FileNotFoundError` if ``credentials.json`` is missing.
+    """
+    if not CREDENTIALS_PATH.exists():
+        raise FileNotFoundError(f"{CREDENTIALS_PATH} not found")
+    _prune_expired_pending_flows()
+    flow = Flow.from_client_secrets_file(
+        str(CREDENTIALS_PATH),
+        scopes=SCOPES,
+        redirect_uri=OAUTH_REDIRECT_URI,
+    )
+    auth_url, state = flow.authorization_url(prompt="consent", access_type="offline")
+    _PENDING_FLOWS[user_id] = (flow, state, time.time() + OAUTH_PENDING_TTL_SECONDS)
+    return auth_url
+
+
+def complete_oauth_flow(user_id: int, redirect_url: str) -> None:
+    """Exchange the auth code in ``redirect_url`` for credentials.
+
+    Validates the URL's ``state`` against the one issued at start (CSRF
+    guard). On success, backs the existing token to ``token.pickle.old``,
+    writes the new token atomically, and busts the cached YouTube client
+    so the next API call uses the fresh creds.
+
+    Raises:
+        LookupError: no pending flow for ``user_id`` (timed out or never started).
+        ValueError: missing/mismatched state, missing code, or token-exchange failure.
+    """
+    _prune_expired_pending_flows()
+    pending = _PENDING_FLOWS.pop(user_id, None)
+    if pending is None:
+        raise LookupError("No pending OAuth flow — run /token renew-start first")
+    flow, expected_state, _ = pending
+
+    parsed = urlparse(redirect_url.strip())
+    qs = parse_qs(parsed.query)
+    received_state = (qs.get("state") or [""])[0]
+    if not received_state or received_state != expected_state:
+        raise ValueError("State mismatch — refusing to exchange code (possible CSRF)")
+    if "code" not in qs:
+        raise ValueError("URL has no `code=` parameter — paste the FULL redirect URL")
+
+    try:
+        flow.fetch_token(authorization_response=redirect_url)
+    except Exception as exc:
+        raise ValueError(f"Token exchange failed: {exc}") from exc
+
+    creds = flow.credentials
+    if TOKEN_PATH.exists():
+        backup = Path(f"{TOKEN_PATH}.old")
+        TOKEN_PATH.replace(backup)
+
+    tmp = Path(f"{TOKEN_PATH}.tmp")
+    with tmp.open("wb") as f:
+        pickle.dump(creds.to_json(), f)
+    tmp.replace(TOKEN_PATH)
+
+    _youtube.cache_clear()
+    get_upload_playlist_id.cache_clear()
 
 
 def get_token_expiration_date() -> datetime | None:

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -407,6 +407,168 @@ async def test_config_unset_reverts_to_fallback(chdir_tmp):
     assert get_settings().cfg.ACELERADO_TICK_SECONDS == 300  # back to default
 
 
+# ---------------------------------------------------------------------------
+# /token group — owner-only OAuth renewal
+# ---------------------------------------------------------------------------
+
+
+def test_register_token_group():
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    cmd = tree.get_command("token", guild=guild)
+    assert cmd is not None
+    assert isinstance(cmd, app_commands.Group)
+    sub_names = {c.name for c in cmd.commands}
+    assert sub_names == {"renew-start", "renew-finish"}
+
+
+def _get_token_subcommand(name: str):
+    tree = _build_tree()
+    guild = discord.Object(id=1)
+    register_commands(tree, guild=guild)
+    group = tree.get_command("token", guild=guild)
+    assert isinstance(group, app_commands.Group)
+    for cmd in group.commands:
+        if cmd.name == name:
+            return cmd
+    raise AssertionError(f"subcommand {name!r} not registered")
+
+
+def _make_token_interaction(user_id: int):
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.user.create_dm = AsyncMock()
+    dm_channel = MagicMock()
+    dm_channel.send = AsyncMock()
+    interaction.user.create_dm.return_value = dm_channel
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction, dm_channel
+
+
+async def test_token_renew_start_rejects_non_owner(monkeypatch):
+    monkeypatch.setenv("DISCORD_OWNER_ID", "999")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_token_subcommand("renew-start")
+    interaction, _ = _make_token_interaction(user_id=42)
+    await cmd.callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "dono" in msg.lower()
+
+
+async def test_token_renew_start_rejects_when_owner_unset(monkeypatch):
+    """Default DISCORD_OWNER_ID=0 — even matching users get refused."""
+    cmd = _get_token_subcommand("renew-start")
+    interaction, _ = _make_token_interaction(user_id=0)
+    await cmd.callback(interaction)
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "dono" in msg.lower()
+
+
+async def test_token_renew_start_dms_url_for_owner(monkeypatch):
+    monkeypatch.setenv("DISCORD_OWNER_ID", "42")
+    from acelerado import youtube
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    monkeypatch.setattr(youtube, "start_oauth_flow", lambda uid: f"https://google/auth?uid={uid}")
+
+    cmd = _get_token_subcommand("renew-start")
+    interaction, dm_channel = _make_token_interaction(user_id=42)
+    await cmd.callback(interaction)
+
+    dm_channel.send.assert_awaited_once()
+    sent = dm_channel.send.await_args.args[0]
+    assert "https://google/auth?uid=42" in sent
+    interaction.response.send_message.assert_awaited_once()
+    assert "DM" in interaction.response.send_message.await_args.args[0]
+
+
+async def test_token_renew_start_handles_blocked_dm(monkeypatch):
+    monkeypatch.setenv("DISCORD_OWNER_ID", "42")
+    from acelerado import youtube
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    monkeypatch.setattr(youtube, "start_oauth_flow", lambda uid: "https://google/auth")
+
+    cmd = _get_token_subcommand("renew-start")
+    interaction, dm_channel = _make_token_interaction(user_id=42)
+    dm_channel.send.side_effect = discord.Forbidden(MagicMock(status=403), "blocked")
+
+    await cmd.callback(interaction)
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "DM" in msg
+
+
+async def test_token_renew_finish_rejects_non_owner(monkeypatch):
+    monkeypatch.setenv("DISCORD_OWNER_ID", "999")
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    cmd = _get_token_subcommand("renew-finish")
+    interaction, _ = _make_token_interaction(user_id=42)
+    await cmd.callback(interaction, redirect_url="http://localhost/?code=x&state=y")
+    interaction.response.send_message.assert_awaited_once()
+
+
+async def test_token_renew_finish_surfaces_value_error(monkeypatch):
+    monkeypatch.setenv("DISCORD_OWNER_ID", "42")
+    from acelerado import youtube
+    from acelerado.config import reload_settings
+
+    reload_settings()
+
+    def boom(user_id, url):
+        raise ValueError("State mismatch — refusing")
+
+    monkeypatch.setattr(youtube, "complete_oauth_flow", boom)
+
+    cmd = _get_token_subcommand("renew-finish")
+    interaction, _ = _make_token_interaction(user_id=42)
+    await cmd.callback(interaction, redirect_url="http://localhost/?code=x&state=evil")
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.args[0]
+    assert "State mismatch" in msg
+
+
+async def test_token_renew_finish_happy_path(monkeypatch):
+    monkeypatch.setenv("DISCORD_OWNER_ID", "42")
+    from acelerado import youtube
+    from acelerado.config import reload_settings
+
+    reload_settings()
+    called = {}
+
+    def fake_complete(user_id, url):
+        called["uid"] = user_id
+        called["url"] = url
+
+    monkeypatch.setattr(youtube, "complete_oauth_flow", fake_complete)
+
+    cmd = _get_token_subcommand("renew-finish")
+    interaction, _ = _make_token_interaction(user_id=42)
+    await cmd.callback(interaction, redirect_url="http://localhost/?code=abc&state=xyz")
+
+    assert called == {"uid": 42, "url": "http://localhost/?code=abc&state=xyz"}
+    interaction.followup.send.assert_awaited_once()
+    msg = interaction.followup.send.await_args.args[0]
+    assert "renovado" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# /update ok path (happy)
+# ---------------------------------------------------------------------------
+
+
 async def test_update_command_ok_schedules_restart(monkeypatch):
     import asyncio
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -246,6 +246,29 @@ async def test_check_expiration_silent_when_more_than_24h(built_state, fake_guil
     fake_guild._log.send.assert_not_awaited()
 
 
+async def test_check_expiration_says_expired_when_negative(built_state, fake_guild, monkeypatch):
+    """Negative time-to-expire means already-expired — say so, don't say 'will expire'."""
+    monkeypatch.setattr(yt_mod, "get_token_time_to_expire", lambda: -3600)
+    monkeypatch.setattr(yt_mod, "get_token_expiration_date", lambda: datetime.now(UTC))
+
+    await built_state.check_expiration()
+    fake_guild._log.send.assert_awaited_once()
+    msg = fake_guild._log.send.await_args.args[0]
+    assert "expirou" in msg.lower()
+    assert "/token renew-start" in msg
+
+
+async def test_check_expiration_hints_renew_command_when_soon(built_state, fake_guild, monkeypatch):
+    monkeypatch.setattr(yt_mod, "get_token_time_to_expire", lambda: 3600)
+    monkeypatch.setattr(yt_mod, "get_token_expiration_date", lambda: datetime.now(UTC))
+
+    await built_state.check_expiration()
+    msg = fake_guild._log.send.await_args.args[0]
+    assert "/token renew-start" in msg
+    # Don't claim it's expired when it isn't.
+    assert "expirou" not in msg.lower()
+
+
 async def test_check_expiration_rate_limits_to_one_per_hour(built_state, fake_guild, monkeypatch):
     monkeypatch.setattr(yt_mod, "get_token_time_to_expire", lambda: 60)
     monkeypatch.setattr(yt_mod, "get_token_expiration_date", lambda: datetime.now(UTC))

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -6,6 +6,7 @@ actual YouTube API is stubbed via ``monkeypatch`` on ``youtube._youtube``.
 
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -223,3 +224,112 @@ def test_time_to_expire_negative_for_past_token(write_token):
     seconds = youtube.get_token_time_to_expire()
     assert seconds is not None
     assert seconds < 0
+
+
+# ---------------------------------------------------------------------------
+# Discord-initiated OAuth renewal flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_flows():
+    youtube._PENDING_FLOWS.clear()
+    yield
+    youtube._PENDING_FLOWS.clear()
+
+
+@pytest.fixture
+def fake_credentials_file(tmp_path):
+    """Write a minimal installed-app credentials.json into the test cwd."""
+    payload = {
+        "installed": {
+            "client_id": "fake-client-id.apps.googleusercontent.com",
+            "client_secret": "fake-secret",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": ["http://localhost"],
+        }
+    }
+    path = tmp_path / "credentials.json"
+    path.write_text(__import__("json").dumps(payload))
+    return path
+
+
+def test_start_oauth_flow_missing_credentials_raises():
+    with pytest.raises(FileNotFoundError):
+        youtube.start_oauth_flow(user_id=42)
+
+
+def test_start_oauth_flow_returns_url_and_parks_flow(monkeypatch, fake_credentials_file):
+    fake_flow = MagicMock(name="Flow")
+    fake_flow.authorization_url.return_value = (
+        "https://accounts.google.com/o/oauth2/auth?state=abc123",
+        "abc123",
+    )
+    monkeypatch.setattr(
+        youtube.Flow,
+        "from_client_secrets_file",
+        classmethod(lambda cls, *a, **kw: fake_flow),
+    )
+
+    url = youtube.start_oauth_flow(user_id=42)
+    assert "state=abc123" in url
+    assert 42 in youtube._PENDING_FLOWS
+    parked_flow, state, _ = youtube._PENDING_FLOWS[42]
+    assert parked_flow is fake_flow
+    assert state == "abc123"
+
+
+def test_complete_oauth_flow_no_pending_raises():
+    with pytest.raises(LookupError):
+        youtube.complete_oauth_flow(user_id=42, redirect_url="http://localhost/?code=x&state=y")
+
+
+def test_complete_oauth_flow_state_mismatch_rejects(monkeypatch):
+    youtube._PENDING_FLOWS[42] = (MagicMock(name="Flow"), "expected-state", time.time() + 600)
+    with pytest.raises(ValueError, match="State mismatch"):
+        youtube.complete_oauth_flow(
+            user_id=42,
+            redirect_url="http://localhost/?code=abc&state=evil-state",
+        )
+    # Flow consumed even on mismatch — user must restart
+    assert 42 not in youtube._PENDING_FLOWS
+
+
+def test_complete_oauth_flow_missing_code_rejects():
+    youtube._PENDING_FLOWS[42] = (MagicMock(name="Flow"), "s1", time.time() + 600)
+    with pytest.raises(ValueError, match="no `code=` parameter"):
+        youtube.complete_oauth_flow(
+            user_id=42,
+            redirect_url="http://localhost/?state=s1",
+        )
+
+
+def test_complete_oauth_flow_writes_token_and_busts_cache(monkeypatch, tmp_path):
+    fake_creds = MagicMock(name="Credentials")
+    fake_creds.to_json.return_value = '{"token": "fresh"}'
+    fake_flow = MagicMock(name="Flow")
+    fake_flow.credentials = fake_creds
+    youtube._PENDING_FLOWS[42] = (fake_flow, "stateXYZ", time.time() + 600)
+
+    # Pre-existing token must be backed up, not silently overwritten.
+    youtube.TOKEN_PATH.write_bytes(b"old-token-bytes")
+
+    youtube.complete_oauth_flow(
+        user_id=42,
+        redirect_url="http://localhost/?code=abc&state=stateXYZ",
+    )
+
+    fake_flow.fetch_token.assert_called_once()
+    assert youtube.TOKEN_PATH.exists()
+    backup = youtube.TOKEN_PATH.with_name(youtube.TOKEN_PATH.name + ".old")
+    assert backup.exists() and backup.read_bytes() == b"old-token-bytes"
+    # Pending entry consumed
+    assert 42 not in youtube._PENDING_FLOWS
+
+
+def test_pending_flows_expire_after_ttl(monkeypatch):
+    fake_flow = MagicMock(name="Flow")
+    youtube._PENDING_FLOWS[42] = (fake_flow, "s1", time.time() - 1)  # already expired
+    youtube._prune_expired_pending_flows()
+    assert 42 not in youtube._PENDING_FLOWS


### PR DESCRIPTION
## Summary
- New owner-gated `/token` slash group: `renew-start` DMs the operator a Google consent URL, `renew-finish` consumes the pasted loopback redirect URL, validates CSRF state, exchanges the code, and writes a fresh `token.pickle` (old one renamed to `token.pickle.old`).
- Owner gating via new `DISCORD_OWNER_ID` env (default `0` = disabled, stricter than `Manage Server`).
- Pending flow parked in memory for 10 min — bot restart drops it, user just re-runs `renew-start`.
- Fixed `check_expiration` saying "will expire in -3600s" once the token had already expired — now distinguishes "expirou há Ns" from "expira em Ns".
- Both expiry-warning paths now point operators at `/token renew-start`.

## Why this shape
Google deprecated true OOB (`urn:ietf:wg:oauth:2.0:oob`) in Oct 2022, so we use the loopback (`http://localhost`) redirect URI shipped with installed-app OAuth clients. The user's browser hits an unreachable URL after consent and they paste the failed-to-load address back — Google never transmits the code anywhere we don't control. Slash command response is ephemeral; the auth code is single-use and short-lived.

## Test plan
- [x] `uv run pytest` — 263 passed
- [x] `uv run mypy acelerado` — clean
- [x] `uv run ruff check acelerado tests` — clean
- [x] Unit coverage: state-mismatch, missing code, no pending flow, TTL expiry, happy path with backup
- [x] Slash registration + owner gating (rejects when owner id unset, rejects non-owner, accepts matching id)
- [x] Regression test for the negative-time-to-expire wording bug
- [x] Live smoke test: invoke `/token renew-start` on the running bot, walk the flow once

🤖 Generated with [Claude Code](https://claude.com/claude-code)